### PR TITLE
Fix: batch id header

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -115,9 +115,11 @@ impl HttpClient for ReqwestHttpClient {
             tracing::trace!(request_id = %request.id, "Added Authorization header");
         }
 
-        // Add fusillade request ID header for analytics correlation
-        req = req.header("X-Fusillade-Request-Id", request.id.to_string());
-        tracing::trace!(request_id = %request.id, "Added X-Fusillade-Request-Id header");
+        // Add fusillade batch and request ID headers for analytics correlation in dwctl
+        // Use the full UUID (request.id.0) instead of the Display impl which only shows 8 chars
+        req = req.header("X-Fusillade-Batch-Id", request.batch_id.0.to_string());
+        req = req.header("X-Fusillade-Request-Id", request.id.0.to_string());
+        tracing::trace!(request_id = %request.id, batch_id = %request.batch_id, "Added X-Fusillade-Batch-Id and X-Fusillade-Request-Id headers");
 
         // Only add body and Content-Type for methods that support a body
         let method_upper = request.method.to_uppercase();


### PR DESCRIPTION
Send fusillade batch id in headers as well as request id.

This enables dwctl to monitor requests and store analytics with fusillade request and batch id columns. Which then enables billing calculations to be done from coalescing results with a matching batch (or request) id. 

This was previously done for batches with just request IDs but due to the volume and size of requests it was impractical to query all batch requests then match their ids. Matching by batch id alone is much more effective.