### PR TITLE
feat: add index for schedulable pending requests query

### DIFF
--- a/migrations/20260127000000_add_pending_schedulable_index.down.sql
+++ b/migrations/20260127000000_add_pending_schedulable_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_requests_pending_batch_not_before_model;

--- a/migrations/20260127000000_add_pending_schedulable_index.up.sql
+++ b/migrations/20260127000000_add_pending_schedulable_index.up.sql
@@ -1,0 +1,21 @@
+-- Add index optimized for finding schedulable pending requests
+-- This supports the query that finds distinct models with pending schedulable requests
+-- for non-cancelled batches:
+--
+--   SELECT DISTINCT r.model FROM requests r
+--   JOIN batches b ON r.batch_id = b.id
+--   WHERE r.state = 'pending'
+--     AND (r.not_before IS NULL OR r.not_before <= $1)
+--     AND b.cancelling_at IS NULL
+--
+-- The index uses NULLS FIRST so that both NULL and small not_before values
+-- are at the start of the index, making the OR condition efficient.
+-- The INCLUDE (model) allows index-only scans for the DISTINCT projection.
+
+CREATE INDEX idx_requests_pending_batch_not_before_model
+ON requests(batch_id, not_before NULLS FIRST)
+INCLUDE (model)
+WHERE state = 'pending';
+
+COMMENT ON INDEX idx_requests_pending_batch_not_before_model IS
+    'Optimized for finding schedulable pending requests: supports batch JOIN, not_before filter, and model projection without heap access';


### PR DESCRIPTION
## Summary
- Adds `idx_requests_pending_batch_not_before_model` index to optimize the query that finds distinct models with pending schedulable requests
- Query was doing a full sequential scan on ~10M rows, taking 35+ seconds
- New index enables index-only scan, reducing query time to ~93ms (385x improvement)

## Index definition
```sql
CREATE INDEX idx_requests_pending_batch_not_before_model
ON requests(batch_id, not_before NULLS FIRST)
INCLUDE (model)
WHERE state = 'pending';
```

## Test plan
- [x] Verified query plan uses new index (EXPLAIN ANALYZE)
- [x] Confirmed 385x performance improvement on production-scale data