### PR TITLE
fix: index list_requests active_first ordering

### DIFF
--- a/migrations/20260416120000_add_requests_active_first_sort_index.down.sql
+++ b/migrations/20260416120000_add_requests_active_first_sort_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_requests_active_first_sort;

--- a/migrations/20260416120000_add_requests_active_first_sort_index.up.sql
+++ b/migrations/20260416120000_add_requests_active_first_sort_index.up.sql
@@ -1,0 +1,28 @@
+-- Expression index supporting list_requests with active_first=true.
+--
+-- list_requests orders by
+--   CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END ASC,
+--   created_at DESC, id DESC
+-- Without an index on that exact expression, the planner has to materialize
+-- the entire filtered JOIN result and sort it, which times out on large data.
+--
+-- Mirrors the idx_batches_active_first_sort pattern already used on `batches`.
+-- Partial on batch_id IS NOT NULL to skip requests orphaned by FK cascade.
+--
+-- NOTE: CREATE INDEX without CONCURRENTLY takes an ACCESS EXCLUSIVE lock for
+-- the duration of the build. On large tables create this CONCURRENTLY ahead
+-- of applying the migration; the IF NOT EXISTS below makes the migration a
+-- no-op in that case:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_active_first_sort
+--   ON requests (
+--     (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+--     created_at DESC,
+--     id DESC
+--   ) WHERE batch_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_requests_active_first_sort
+ON requests (
+  (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+  created_at DESC,
+  id DESC
+) WHERE batch_id IS NOT NULL;

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -12217,6 +12217,89 @@ mod tests {
     }
 
     #[sqlx::test]
+    async fn test_list_requests_active_first_ordering(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        // Create a batch with several requests
+        let templates: Vec<RequestTemplateInput> = (0..4)
+            .map(|i| RequestTemplateInput {
+                custom_id: Some(format!("af-{}", i)),
+                endpoint: "https://api.example.com".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/chat/completions".to_string(),
+                body: "{}".to_string(),
+                model: "gpt-4".to_string(),
+                api_key: "key".to_string(),
+            })
+            .collect();
+
+        let file_id = manager
+            .create_file("af-file".to_string(), None, templates)
+            .await
+            .unwrap();
+        let batch = manager
+            .create_batch(crate::batch::BatchInput {
+                file_id,
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: "1h".to_string(),
+                metadata: None,
+                created_by: None,
+                api_key_id: None,
+                api_key: None,
+                total_requests: None,
+            })
+            .await
+            .unwrap();
+
+        // Force distinct states on the requests so we can verify priority ordering.
+        // Priority mapping in list_requests: processing=0, claimed=1, pending=2, else=3.
+        // Set one each of completed, processing, claimed, pending.
+        let req_ids: Vec<uuid::Uuid> = sqlx::query_scalar(
+            "SELECT id FROM requests WHERE batch_id = $1 ORDER BY created_at ASC, id ASC",
+        )
+        .bind(*batch.id as uuid::Uuid)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(req_ids.len(), 4);
+
+        // Update states directly (bypassing state machine) purely for ordering test.
+        // Indices: [0]=completed, [1]=processing, [2]=claimed, [3]=pending
+        sqlx::query("UPDATE requests SET state='completed', response_status=200, response_body='{}', completed_at=NOW() WHERE id=$1")
+            .bind(req_ids[0])
+            .execute(&pool).await.unwrap();
+        sqlx::query("UPDATE requests SET state='processing', daemon_id=gen_random_uuid(), claimed_at=NOW(), started_at=NOW() WHERE id=$1")
+            .bind(req_ids[1])
+            .execute(&pool).await.unwrap();
+        sqlx::query("UPDATE requests SET state='claimed', daemon_id=gen_random_uuid(), claimed_at=NOW() WHERE id=$1")
+            .bind(req_ids[2])
+            .execute(&pool).await.unwrap();
+        // req_ids[3] stays pending
+
+        let result = manager
+            .list_requests(crate::request::ListRequestsFilter {
+                active_first: true,
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.data.len(), 4);
+        let states: Vec<&str> = result.data.iter().map(|r| r.status.as_str()).collect();
+        // Expected: processing (0), claimed (1), pending (2), completed (3)
+        assert_eq!(
+            states,
+            vec!["processing", "claimed", "pending", "completed"],
+            "active_first must order by state priority"
+        );
+    }
+
+    #[sqlx::test]
     async fn test_get_request_detail(pool: sqlx::PgPool) {
         let http_client = Arc::new(MockHttpClient::new());
         let manager = PostgresRequestManager::with_client(


### PR DESCRIPTION
## Summary

The admin UI call
`GET /admin/api/v1/batches/requests?limit=10&completion_window=1h&active_first=true`
was timing out (>60s) on large datasets, leaving the page unable to render.

`active_first=true` produces an ORDER BY whose leading key is a CASE expression mapping request states to priorities (`processing=0, claimed=1, pending=2, else=3`). No existing index could serve that sort, so the planner materialized the entire filtered JOIN result and sorted it — unworkable at scale.

## Changes

- New migration adding partial expression b-tree index on requests:
  ```sql
  CREATE INDEX idx_requests_active_first_sort ON requests (
    (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
    created_at DESC,
    id DESC
  ) WHERE batch_id IS NOT NULL;
  ```
  Mirrors the existing `idx_batches_active_first_sort` pattern on `batches`. Query's ORDER BY now matches the index exactly, so the planner emits rows already sorted and stops at LIMIT.

- Rollout note recommends `CREATE INDEX CONCURRENTLY` on large production tables ahead of applying the migration; `IF NOT EXISTS` keeps the migration a no-op in that case.

- New test `test_list_requests_active_first_ordering` asserts the priority ordering (processing → claimed → pending → terminal) end-to-end.

## Verification (staging)

Index built with `CREATE INDEX CONCURRENTLY` on the live staging DB; then measured the exact UI query:

| Query | Before | After (cold) | After (warm) |
|---|---|---|---|
| `active_first=true, completion_window=1h, limit=10` | **60 s timeout** | **9 ms** | **1.7 ms** |
| `active_first=true, limit=50` (no other filter) | 60 s+ | — | **0.3 ms** |

Plan shows `Index Scan using idx_requests_active_first_sort` on both variants.

## Test plan

- [x] All 136 tests pass locally
- [x] Index built on staging via `CREATE INDEX CONCURRENTLY`
- [x] Staging UI query measured sub-10ms
- [x] New test verifies state-priority ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)