### PR TITLE
feat: request methods for external daemons

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -11,8 +11,8 @@ use crate::daemon::{AnyDaemonRecord, DaemonRecord, DaemonState, DaemonStatus};
 use crate::error::Result;
 use crate::http::HttpClient;
 use crate::request::{
-    AnyRequest, CascadeTargetState, Claimed, DaemonId, ListRequestsFilter, Request, RequestDetail,
-    RequestId, RequestListResult, RequestState,
+    AnyRequest, CascadeTargetState, Claimed, CreateDaemonRequestInput, DaemonId,
+    ListRequestsFilter, Request, RequestDetail, RequestId, RequestListResult, RequestState,
 };
 use async_trait::async_trait;
 use futures::stream::Stream;
@@ -382,6 +382,37 @@ pub trait Storage: Send + Sync {
 
     /// Get a single request by ID with full detail (body, response, error).
     async fn get_request_detail(&self, request_id: RequestId) -> Result<RequestDetail>;
+
+    /// Create a request being processed by a daemon, without a batch.
+    ///
+    /// Inserts a request template and a request row with `batch_id = NULL` in
+    /// "processing" state. Used when an external daemon (e.g., an AI proxy) is
+    /// already handling the request and wants to track it in fusillade.
+    async fn create_daemon_request(
+        &self,
+        input: CreateDaemonRequestInput,
+    ) -> Result<RequestId>;
+
+    /// Complete a processing request with the response body.
+    ///
+    /// Transitions the request from "processing" to "completed" and stores the
+    /// response body and HTTP status code.
+    async fn complete_request(
+        &self,
+        request_id: RequestId,
+        response_body: &str,
+        status_code: u16,
+    ) -> Result<()>;
+
+    /// Fail a processing request with an error message.
+    ///
+    /// Transitions the request from "processing" to "failed" and stores the
+    /// error message as a JSON object.
+    async fn fail_request(
+        &self,
+        request_id: RequestId,
+        error: &str,
+    ) -> Result<()>;
 }
 
 /// Daemon lifecycle persistence.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -388,10 +388,7 @@ pub trait Storage: Send + Sync {
     /// Inserts a request template and a request row with `batch_id = NULL` in
     /// "processing" state. Used when an external daemon (e.g., an AI proxy) is
     /// already handling the request and wants to track it in fusillade.
-    async fn create_daemon_request(
-        &self,
-        input: CreateDaemonRequestInput,
-    ) -> Result<RequestId>;
+    async fn create_daemon_request(&self, input: CreateDaemonRequestInput) -> Result<RequestId>;
 
     /// Complete a processing request with the response body.
     ///
@@ -408,11 +405,7 @@ pub trait Storage: Send + Sync {
     ///
     /// Transitions the request from "processing" to "failed" and stores the
     /// error message as a JSON object.
-    async fn fail_request(
-        &self,
-        request_id: RequestId,
-        error: &str,
-    ) -> Result<()>;
+    async fn fail_request(&self, request_id: RequestId, error: &str) -> Result<()>;
 }
 
 /// Daemon lifecycle persistence.

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3568,10 +3568,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         Ok(detail)
     }
 
-    async fn create_daemon_request(
-        &self,
-        input: CreateDaemonRequestInput,
-    ) -> Result<RequestId> {
+    async fn create_daemon_request(&self, input: CreateDaemonRequestInput) -> Result<RequestId> {
         let pool = self.pools.write();
         let id = input.id.unwrap_or_else(Uuid::new_v4);
         let template_id = Uuid::new_v4();
@@ -3640,11 +3637,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         Ok(())
     }
 
-    async fn fail_request(
-        &self,
-        request_id: RequestId,
-        error: &str,
-    ) -> Result<()> {
+    async fn fail_request(&self, request_id: RequestId, error: &str) -> Result<()> {
         let pool = self.pools.write();
 
         let error_json = serde_json::json!({

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -12849,9 +12849,9 @@ mod tests {
 
         assert_eq!(detail.model, "gpt-4");
         assert_eq!(detail.status, "pending");
-        assert_eq!(detail.batch_id, batch.id.0);
-        assert_eq!(detail.completion_window, "1h");
-        assert_eq!(detail.batch_created_by, "test-user-id");
+        assert_eq!(detail.batch_id, Some(batch.id.0));
+        assert_eq!(detail.completion_window, Some("1h".to_string()));
+        assert_eq!(detail.batch_created_by, Some("test-user-id".to_string()));
         assert!(detail.body.as_deref().unwrap().contains("gpt-4"));
     }
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -36,8 +36,8 @@ use crate::daemon::{
 use crate::error::{FusilladeError, Result};
 use crate::http::HttpClient;
 use crate::request::{
-    Canceled, CascadeTargetState, Claimed, Completed, DaemonId, Failed, FailureReason, Pending,
-    Processing, Request, RequestData, RequestId, RequestState,
+    Canceled, CascadeTargetState, Claimed, Completed, CreateDaemonRequestInput, DaemonId, Failed,
+    FailureReason, Pending, Processing, Request, RequestData, RequestId, RequestState,
 };
 
 use super::DaemonExecutor;
@@ -3566,6 +3566,108 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .ok_or(FusilladeError::RequestNotFound(request_id))?;
 
         Ok(detail)
+    }
+
+    async fn create_daemon_request(
+        &self,
+        input: CreateDaemonRequestInput,
+    ) -> Result<RequestId> {
+        let pool = self.pools.write();
+        let id = input.id.unwrap_or_else(Uuid::new_v4);
+        let template_id = Uuid::new_v4();
+        let now = Utc::now();
+
+        // Insert template row (file_id = NULL for daemon-managed requests)
+        sqlx::query(
+            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key)
+             VALUES ($1, NULL, NULL, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(template_id)
+        .bind(&input.endpoint)
+        .bind(&input.method)
+        .bind(&input.path)
+        .bind(&input.body)
+        .bind(&input.model)
+        .bind(&input.api_key)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request template: {}", e)))?;
+
+        // Insert request row in processing state (batch_id = NULL)
+        sqlx::query(
+            "INSERT INTO requests (id, batch_id, template_id, model, custom_id, state, daemon_id, claimed_at, started_at)
+             VALUES ($1, NULL, $2, $3, NULL, 'processing', $4, $5, $6)",
+        )
+        .bind(id)
+        .bind(template_id)
+        .bind(&input.model)
+        .bind(input.daemon_id.0)
+        .bind(now)
+        .bind(now)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request: {}", e)))?;
+
+        Ok(RequestId(id))
+    }
+
+    async fn complete_request(
+        &self,
+        request_id: RequestId,
+        response_body: &str,
+        status_code: u16,
+    ) -> Result<()> {
+        let pool = self.pools.write();
+        let size = response_body.len() as i64;
+
+        sqlx::query(
+            "UPDATE requests
+             SET state = 'completed',
+                 response_status = $2,
+                 response_body = $3,
+                 response_size = $4,
+                 completed_at = NOW()
+             WHERE id = $1 AND state = 'processing'",
+        )
+        .bind(request_id.0)
+        .bind(status_code as i16)
+        .bind(response_body)
+        .bind(size)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to complete request: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn fail_request(
+        &self,
+        request_id: RequestId,
+        error: &str,
+    ) -> Result<()> {
+        let pool = self.pools.write();
+
+        let error_json = serde_json::json!({
+            "type": "NonRetriableHttpStatus",
+            "status": 500,
+            "message": error,
+        })
+        .to_string();
+
+        sqlx::query(
+            "UPDATE requests
+             SET state = 'failed',
+                 error = $2,
+                 failed_at = NOW()
+             WHERE id = $1 AND state = 'processing'",
+        )
+        .bind(request_id.0)
+        .bind(&error_json)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail request: {}", e)))?;
+
+        Ok(())
     }
 }
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3551,11 +3551,17 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                     THEN EXTRACT(EPOCH FROM (r.completed_at - r.started_at)) * 1000
                     ELSE NULL END)::float8 as duration_ms,
                 r.response_status,
-                t.body, r.response_body, r.error,
+                -- Null out template body when the parent file is soft-deleted
+                -- (preserves existing behavior for batch requests). Daemon-managed
+                -- templates (file_id IS NULL) always return their body.
+                CASE WHEN f.deleted_at IS NULL OR t.file_id IS NULL
+                    THEN t.body ELSE NULL END as body,
+                r.response_body, r.error,
                 b.completion_window, r.service_tier, b.created_by as batch_created_by
             FROM requests r
             LEFT JOIN batches b ON r.batch_id = b.id
-            LEFT JOIN active_request_templates t ON r.template_id = t.id
+            LEFT JOIN request_templates t ON r.template_id = t.id
+            LEFT JOIN files f ON t.file_id = f.id
             WHERE r.id = $1 AND (b.deleted_at IS NULL OR r.batch_id IS NULL)
             "#,
         )
@@ -3574,6 +3580,11 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let template_id = Uuid::new_v4();
         let now = Utc::now();
 
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to begin transaction: {}", e)))?;
+
         // Insert template row (file_id = NULL for daemon-managed requests)
         sqlx::query(
             "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key)
@@ -3586,7 +3597,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&input.body)
         .bind(&input.model)
         .bind(&input.api_key)
-        .execute(pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request template: {}", e)))?;
 
@@ -3601,9 +3612,13 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(input.daemon_id.0)
         .bind(now)
         .bind(now)
-        .execute(pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request: {}", e)))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to commit daemon request transaction: {}", e)))?;
 
         Ok(RequestId(id))
     }
@@ -3617,7 +3632,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let pool = self.pools.write();
         let size = response_body.len() as i64;
 
-        sqlx::query(
+        let result = sqlx::query(
             "UPDATE requests
              SET state = 'completed',
                  response_status = $2,
@@ -3634,20 +3649,24 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to complete request: {}", e)))?;
 
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::RequestNotFound(request_id));
+        }
+
         Ok(())
     }
 
     async fn fail_request(&self, request_id: RequestId, error: &str) -> Result<()> {
         let pool = self.pools.write();
 
-        let error_json = serde_json::json!({
-            "type": "NonRetriableHttpStatus",
-            "status": 500,
-            "message": error,
-        })
-        .to_string();
+        let reason = FailureReason::NonRetriableHttpStatus {
+            status: 500,
+            body: error.to_string(),
+        };
+        let error_json = serde_json::to_string(&reason)
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to serialize failure reason: {}", e)))?;
 
-        sqlx::query(
+        let result = sqlx::query(
             "UPDATE requests
              SET state = 'failed',
                  error = $2,
@@ -3659,6 +3678,10 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .execute(pool)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail request: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::RequestNotFound(request_id));
+        }
 
         Ok(())
     }

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3554,9 +3554,9 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 t.body, r.response_body, r.error,
                 b.completion_window, r.service_tier, b.created_by as batch_created_by
             FROM requests r
-            JOIN batches b ON r.batch_id = b.id
+            LEFT JOIN batches b ON r.batch_id = b.id
             LEFT JOIN active_request_templates t ON r.template_id = t.id
-            WHERE r.id = $1 AND b.deleted_at IS NULL
+            WHERE r.id = $1 AND (b.deleted_at IS NULL OR r.batch_id IS NULL)
             "#,
         )
         .bind(request_id.0)

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3616,9 +3616,12 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request: {}", e)))?;
 
-        tx.commit()
-            .await
-            .map_err(|e| FusilladeError::Other(anyhow!("Failed to commit daemon request transaction: {}", e)))?;
+        tx.commit().await.map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to commit daemon request transaction: {}",
+                e
+            ))
+        })?;
 
         Ok(RequestId(id))
     }
@@ -3663,8 +3666,9 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             status: 500,
             body: error.to_string(),
         };
-        let error_json = serde_json::to_string(&reason)
-            .map_err(|e| FusilladeError::Other(anyhow!("Failed to serialize failure reason: {}", e)))?;
+        let error_json = serde_json::to_string(&reason).map_err(|e| {
+            FusilladeError::Other(anyhow!("Failed to serialize failure reason: {}", e))
+        })?;
 
         let result = sqlx::query(
             "UPDATE requests
@@ -9913,7 +9917,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let batch = manager
+            let _batch = manager
                 .create_batch(BatchInput {
                     file_id,
                     endpoint: "/v1/chat/completions".to_string(),

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -12,6 +12,9 @@ pub mod types;
 // Re-export commonly used types
 #[allow(deprecated)]
 pub use query::RequestSummaryWithCount;
-pub use query::{ListRequestsFilter, RequestDetail, RequestListResult, RequestSummary};
+pub use query::{
+    CreateDaemonRequestInput, ListRequestsFilter, RequestDetail, RequestListResult,
+    RequestSummary,
+};
 pub use transitions::CancellationReason;
 pub use types::*;

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -13,8 +13,7 @@ pub mod types;
 #[allow(deprecated)]
 pub use query::RequestSummaryWithCount;
 pub use query::{
-    CreateDaemonRequestInput, ListRequestsFilter, RequestDetail, RequestListResult,
-    RequestSummary,
+    CreateDaemonRequestInput, ListRequestsFilter, RequestDetail, RequestListResult, RequestSummary,
 };
 pub use transitions::CancellationReason;
 pub use types::*;

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -163,6 +163,31 @@ pub struct RequestDetail {
     pub batch_created_by: String,
 }
 
+/// Input for creating a daemon-managed request (no batch).
+///
+/// Used when a daemon (e.g., an AI proxy) is already processing a request and
+/// wants to track it in fusillade without creating a batch. The request is
+/// created directly in "processing" state with the specified daemon ID.
+#[derive(Debug, Clone)]
+pub struct CreateDaemonRequestInput {
+    /// Pre-generated request ID. If `None`, a new UUID is generated.
+    pub id: Option<Uuid>,
+    /// The request body as a JSON string.
+    pub body: String,
+    /// Model identifier.
+    pub model: String,
+    /// Base URL of the target endpoint (e.g., "http://localhost:3001/ai").
+    pub endpoint: String,
+    /// HTTP method (e.g., "POST").
+    pub method: String,
+    /// API path (e.g., "/v1/responses").
+    pub path: String,
+    /// API key for the request (empty string if none).
+    pub api_key: String,
+    /// The daemon that is processing this request.
+    pub daemon_id: super::DaemonId,
+}
+
 /// Result of a paginated request list query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestListResult {

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -145,7 +145,8 @@ pub use deprecated_types::RequestSummaryWithCount;
 #[cfg_attr(feature = "postgres", derive(sqlx::FromRow))]
 pub struct RequestDetail {
     pub id: Uuid,
-    pub batch_id: Uuid,
+    /// `None` for daemon-managed requests (created via `create_daemon_request`).
+    pub batch_id: Option<Uuid>,
     pub model: String,
     #[cfg_attr(feature = "postgres", sqlx(rename = "state"))]
     pub status: String,
@@ -158,9 +159,11 @@ pub struct RequestDetail {
     pub body: Option<String>,
     pub response_body: Option<String>,
     pub error: Option<String>,
-    pub completion_window: String,
+    /// `None` for daemon-managed requests (no batch).
+    pub completion_window: Option<String>,
     pub service_tier: Option<String>,
-    pub batch_created_by: String,
+    /// `None` for daemon-managed requests (no batch).
+    pub batch_created_by: Option<String>,
 }
 
 /// Input for creating a daemon-managed request (no batch).


### PR DESCRIPTION
## Summary

- Add `create_daemon_request(input)` for creating requests with `batch_id=NULL` and state=processing, used by external daemons (e.g. dwctl's responses middleware) that manage their own request lifecycle
- Add `complete_request(id, body, status)` and `fail_request(id, error)` for transitioning daemon-managed requests to terminal states
- Extend `RequestDetail` to support batchless requests by making `batch_id`, `completion_window`, and `batch_created_by` optional

## Test plan

- [x] Existing tests pass with updated Option type assertions
- [x] New methods tested via control-layer integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)