### PR TITLE
feat: create single request batch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use daemon::{Daemon, DaemonConfig, ModelEscalationConfig};
 pub use error::{FusilladeError, Result};
 pub use http::{HttpClient, HttpResponse, MockHttpClient, ReqwestHttpClient, StreamReassembler};
 pub use manager::postgres::{PoolProvider, PostgresRequestManager, TestDbPools};
-pub use manager::{DaemonExecutor, Storage};
+pub use manager::{CreateSingleRequestBatchInput, DaemonExecutor, Storage};
 pub use request::*;
 
 /// Get the fusillade database migrator

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -10,6 +10,7 @@ use crate::batch::{
 use crate::daemon::{AnyDaemonRecord, DaemonRecord, DaemonState, DaemonStatus};
 use crate::error::Result;
 use crate::http::HttpClient;
+use uuid::Uuid;
 use crate::request::{
     AnyRequest, CascadeTargetState, Claimed, CreateDaemonRequestInput, DaemonId,
     ListRequestsFilter, Request, RequestDetail, RequestId, RequestListResult, RequestState,
@@ -24,6 +25,31 @@ use tokio::task::JoinHandle;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 mod utils;
+
+/// Input for creating a single-request batch with a pre-generated request ID.
+#[derive(Debug, Clone)]
+pub struct CreateSingleRequestBatchInput {
+    /// Pre-generated request UUID. Becomes the request's primary key.
+    pub request_id: Uuid,
+    /// Request body (JSON string).
+    pub body: String,
+    /// Model name for the request.
+    pub model: String,
+    /// Base URL for the daemon to reach the proxy (e.g., `http://localhost:3001/ai`).
+    pub base_url: String,
+    /// API path (e.g., `/v1/responses`, `/v1/chat/completions`).
+    pub endpoint: String,
+    /// Completion window (e.g., `"0s"` for realtime, `"1h"` for flex).
+    pub completion_window: String,
+    /// Initial request state. Use `"pending"` for daemon-processed requests
+    /// (flex) or `"processing"` for externally-managed requests (realtime)
+    /// that the daemon should not claim.
+    pub initial_state: String,
+    /// API key for request execution and batch attribution.
+    pub api_key: Option<String>,
+    /// User/org ID that owns this batch.
+    pub created_by: Option<String>,
+}
 
 /// Storage trait for persisting and querying requests.
 ///
@@ -120,6 +146,18 @@ pub trait Storage: Send + Sync {
     /// If the file has no templates, returns a [`ValidationError`](crate::FusilladeError::ValidationError)
     /// and the caller is responsible for marking the batch as failed.
     async fn populate_batch(&self, batch_id: BatchId, file_id: FileId) -> Result<()>;
+
+    /// Create a single-request batch with a pre-generated request ID.
+    ///
+    /// Atomically creates a file, template, batch, and request in one call.
+    /// The request ID is caller-specified so it can be known upfront without
+    /// a round-trip. Used for tracking realtime and flex responses where the
+    /// caller needs the ID before the request is processed.
+    ///
+    /// The request is created in `pending` state. For realtime requests
+    /// (completion_window `0s`), the caller proxies via an external daemon
+    /// and completes the row via the outlet handler.
+    async fn create_single_request_batch(&self, input: CreateSingleRequestBatchInput) -> Result<Batch>;
 
     /// Get a batch by ID.
     ///

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -154,9 +154,10 @@ pub trait Storage: Send + Sync {
     /// a round-trip. Used for tracking realtime and flex responses where the
     /// caller needs the ID before the request is processed.
     ///
-    /// The request is created in `pending` state. For realtime requests
-    /// (completion_window `0s`), the caller proxies via an external daemon
-    /// and completes the row via the outlet handler.
+    /// The request is created with the caller-specified `initial_state`:
+    /// - `"pending"` — daemon-processed (e.g. flex). The daemon will claim it.
+    /// - `"processing"` — externally-managed (e.g. realtime). The daemon
+    ///   ignores it; the caller completes/fails the row directly.
     async fn create_single_request_batch(
         &self,
         input: CreateSingleRequestBatchInput,

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -10,7 +10,6 @@ use crate::batch::{
 use crate::daemon::{AnyDaemonRecord, DaemonRecord, DaemonState, DaemonStatus};
 use crate::error::Result;
 use crate::http::HttpClient;
-use uuid::Uuid;
 use crate::request::{
     AnyRequest, CascadeTargetState, Claimed, CreateDaemonRequestInput, DaemonId,
     ListRequestsFilter, Request, RequestDetail, RequestId, RequestListResult, RequestState,
@@ -21,6 +20,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
+use uuid::Uuid;
 
 #[cfg(feature = "postgres")]
 pub mod postgres;
@@ -157,7 +157,10 @@ pub trait Storage: Send + Sync {
     /// The request is created in `pending` state. For realtime requests
     /// (completion_window `0s`), the caller proxies via an external daemon
     /// and completes the row via the outlet handler.
-    async fn create_single_request_batch(&self, input: CreateSingleRequestBatchInput) -> Result<Batch>;
+    async fn create_single_request_batch(
+        &self,
+        input: CreateSingleRequestBatchInput,
+    ) -> Result<Batch>;
 
     /// Get a batch by ID.
     ///

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2260,15 +2260,15 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let file_id = Uuid::new_v4();
         let batch_id = Uuid::new_v4();
 
-        let std_duration =
-            humantime::parse_duration(&input.completion_window).map_err(|e| {
-                FusilladeError::Other(anyhow!(
-                    "Invalid completion_window '{}': {}",
-                    input.completion_window,
-                    e
-                ))
-            })?;
-        let expires_at = now + chrono::Duration::from_std(std_duration).unwrap_or(chrono::Duration::hours(24));
+        let std_duration = humantime::parse_duration(&input.completion_window).map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Invalid completion_window '{}': {}",
+                input.completion_window,
+                e
+            ))
+        })?;
+        let expires_at =
+            now + chrono::Duration::from_std(std_duration).unwrap_or(chrono::Duration::hours(24));
         let service_tier =
             crate::request::query::service_tier_from_completion_window(&input.completion_window);
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2249,6 +2249,109 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         self.get_batch_from_pool(batch.id, self.pools.write()).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, input), fields(request_id = %input.request_id))]
+    async fn create_single_request_batch(
+        &self,
+        input: super::CreateSingleRequestBatchInput,
+    ) -> Result<Batch> {
+        let pool = self.pools.write();
+        let now = Utc::now();
+        let template_id = Uuid::new_v4();
+        let file_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+
+        let std_duration =
+            humantime::parse_duration(&input.completion_window).map_err(|e| {
+                FusilladeError::Other(anyhow!(
+                    "Invalid completion_window '{}': {}",
+                    input.completion_window,
+                    e
+                ))
+            })?;
+        let expires_at = now + chrono::Duration::from_std(std_duration).unwrap_or(chrono::Duration::hours(24));
+        let service_tier =
+            crate::request::query::service_tier_from_completion_window(&input.completion_window);
+
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to begin transaction: {}", e)))?;
+
+        // 1. Create file (no physical file — just a container for the template)
+        sqlx::query(
+            "INSERT INTO files (id, name, purpose, created_at, updated_at)
+             VALUES ($1, 'single_request', 'batch', $2, $2)",
+        )
+        .bind(file_id)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to create file: {}", e)))?;
+
+        // 2. Create template
+        sqlx::query(
+            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key)
+             VALUES ($1, $2, NULL, $3, 'POST', $4, $5, $6, $7)",
+        )
+        .bind(template_id)
+        .bind(file_id)
+        .bind(&input.base_url)
+        .bind(&input.endpoint)
+        .bind(&input.body)
+        .bind(&input.model)
+        .bind(input.api_key.as_deref().unwrap_or(""))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to create template: {}", e)))?;
+
+        // 3. Create batch
+        sqlx::query(
+            "INSERT INTO batches (id, file_id, endpoint, completion_window, created_at, expires_at, created_by, total_requests, requests_started_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 1, $5)",
+        )
+        .bind(batch_id)
+        .bind(file_id)
+        .bind(&input.endpoint)
+        .bind(&input.completion_window)
+        .bind(now)
+        .bind(expires_at)
+        .bind(input.created_by.as_deref())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to create batch: {}", e)))?;
+
+        // 4. Create request with caller-specified ID and state.
+        // When initial_state is 'processing', set daemon_id/claimed_at/started_at
+        // to satisfy the processing_fields_check constraint.
+        let (daemon_id, claimed_at, started_at) = if input.initial_state == "processing" {
+            (Some(input.request_id), Some(now), Some(now))
+        } else {
+            (None, None, None)
+        };
+        sqlx::query(
+            "INSERT INTO requests (id, batch_id, template_id, state, retry_attempt, model, service_tier, daemon_id, claimed_at, started_at)
+             VALUES ($1, $2, $3, $4, 0, $5, $6, $7, $8, $9)",
+        )
+        .bind(input.request_id)
+        .bind(batch_id)
+        .bind(template_id)
+        .bind(&input.initial_state)
+        .bind(&input.model)
+        .bind(service_tier)
+        .bind(daemon_id)
+        .bind(claimed_at)
+        .bind(started_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to create request: {}", e)))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to commit transaction: {}", e)))?;
+
+        self.get_batch_from_pool(BatchId(batch_id), pool).await
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     async fn create_batch_record(&self, input: BatchInput) -> Result<Batch> {
         let now = Utc::now();
@@ -3403,8 +3506,8 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
 
         let where_clause = format!(
             r#"
-            WHERE b.deleted_at IS NULL
-              AND ($1::text IS NULL OR b.created_by = $1)
+            WHERE (b.deleted_at IS NULL OR r.batch_id IS NULL)
+              AND ($1::text IS NULL OR b.created_by = $1 OR r.batch_id IS NULL)
               AND ($2::text IS NULL OR b.completion_window = $2)
               AND ($3::text IS NULL OR r.state = $3)
               AND ($4::text[] IS NULL OR r.model = ANY($4))
@@ -3424,7 +3527,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             r#"
             SELECT COUNT(*)::bigint
             FROM requests r
-            JOIN batches b ON r.batch_id = b.id
+            LEFT JOIN batches b ON r.batch_id = b.id
             {where_clause}
             "#
         );
@@ -3472,7 +3575,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 EXPLAIN (FORMAT JSON)
                 SELECT 1
                 FROM requests r
-                JOIN batches b ON r.batch_id = b.id
+                LEFT JOIN batches b ON r.batch_id = b.id
                 {where_clause}
                 "#
             ))
@@ -3513,7 +3616,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 r.service_tier,
                 b.created_by as batch_created_by
             FROM requests r
-            JOIN batches b ON r.batch_id = b.id
+            LEFT JOIN batches b ON r.batch_id = b.id
             {where_clause}
             ORDER BY {order_clause}
             LIMIT $8 OFFSET $9

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3518,6 +3518,12 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             "AND ($7::text IS NULL)" // tautology that consumes the bind slot
         };
 
+        let require_tier_clause = if filter.require_service_tier {
+            "AND r.service_tier IS NOT NULL"
+        } else {
+            ""
+        };
+
         let where_clause = format!(
             r#"
             WHERE (b.deleted_at IS NULL OR r.batch_id IS NULL)
@@ -3528,6 +3534,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
               AND ($5::timestamptz IS NULL OR r.created_at >= $5)
               AND ($6::timestamptz IS NULL OR r.created_at <= $6)
               {service_tier_clause}
+              {require_tier_clause}
         "#
         );
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3710,9 +3710,10 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             .map_err(|e| FusilladeError::Other(anyhow!("Failed to begin transaction: {}", e)))?;
 
         // Insert template row (file_id = NULL for daemon-managed requests)
+        let body_byte_size = input.body.len() as i64;
         sqlx::query(
-            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key)
-             VALUES ($1, NULL, NULL, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key, body_byte_size)
+             VALUES ($1, NULL, NULL, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(template_id)
         .bind(&input.endpoint)
@@ -3721,6 +3722,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&input.body)
         .bind(&input.model)
         .bind(&input.api_key)
+        .bind(body_byte_size)
         .execute(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert daemon request template: {}", e)))?;
@@ -3794,15 +3796,18 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             FusilladeError::Other(anyhow!("Failed to serialize failure reason: {}", e))
         })?;
 
+        let error_size = error_json.len() as i64;
         let result = sqlx::query(
             "UPDATE requests
              SET state = 'failed',
                  error = $2,
+                 response_size = $3,
                  failed_at = NOW()
              WHERE id = $1 AND state = 'processing'",
         )
         .bind(request_id.0)
         .bind(&error_json)
+        .bind(error_size)
         .execute(pool)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail request: {}", e)))?;
@@ -13163,5 +13168,245 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // create_single_request_batch tests
+    // =========================================================================
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_pending(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "1h".to_string(),
+                initial_state: "pending".to_string(),
+                api_key: None,
+                created_by: Some("user-123".to_string()),
+            })
+            .await
+            .expect("create_single_request_batch should succeed");
+
+        // Verify batch was created
+        assert_eq!(batch.total_requests, 1);
+
+        // Verify request exists with correct state and service_tier
+        let detail = manager
+            .get_request_detail(crate::request::RequestId(request_id))
+            .await
+            .expect("request should exist");
+        assert_eq!(detail.status, "pending");
+        assert_eq!(detail.service_tier, Some("flex".to_string()));
+        assert_eq!(detail.batch_id, Some(batch.id.0));
+        assert_eq!(detail.batch_created_by, Some("user-123".to_string()));
+        assert!(detail.body.is_some());
+    }
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_processing(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let _batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "0s".to_string(),
+                initial_state: "processing".to_string(),
+                api_key: None,
+                created_by: Some("user-456".to_string()),
+            })
+            .await
+            .expect("create_single_request_batch should succeed");
+
+        // Verify request is in processing state with sentinel daemon_id
+        let detail = manager
+            .get_request_detail(crate::request::RequestId(request_id))
+            .await
+            .expect("request should exist");
+        assert_eq!(detail.status, "processing");
+        assert_eq!(detail.service_tier, Some("priority".to_string()));
+    }
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_without_created_by(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let _batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"input":"test"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "1h".to_string(),
+                initial_state: "pending".to_string(),
+                api_key: None,
+                created_by: None,
+            })
+            .await
+            .expect("should succeed with created_by=None");
+
+        // Should be created with empty created_by (not NULL)
+        let detail = manager
+            .get_request_detail(crate::request::RequestId(request_id))
+            .await
+            .expect("request should exist");
+        assert_eq!(detail.batch_created_by, Some("".to_string()));
+    }
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_complete_lifecycle(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let _batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"input":"test"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "0s".to_string(),
+                initial_state: "processing".to_string(),
+                api_key: None,
+                created_by: Some("user-789".to_string()),
+            })
+            .await
+            .expect("create should succeed");
+
+        // Complete the request
+        manager
+            .complete_request(
+                crate::request::RequestId(request_id),
+                r#"{"output":"done"}"#,
+                200,
+            )
+            .await
+            .expect("complete should succeed");
+
+        let detail = manager
+            .get_request_detail(crate::request::RequestId(request_id))
+            .await
+            .expect("request should exist");
+        assert_eq!(detail.status, "completed");
+        assert_eq!(
+            detail.response_body,
+            Some(r#"{"output":"done"}"#.to_string())
+        );
+        assert!(detail.completed_at.is_some());
+    }
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_fail_lifecycle(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let _batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"input":"test"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "0s".to_string(),
+                initial_state: "processing".to_string(),
+                api_key: None,
+                created_by: Some("user-789".to_string()),
+            })
+            .await
+            .expect("create should succeed");
+
+        // Fail the request
+        manager
+            .fail_request(crate::request::RequestId(request_id), "upstream timeout")
+            .await
+            .expect("fail should succeed");
+
+        let detail = manager
+            .get_request_detail(crate::request::RequestId(request_id))
+            .await
+            .expect("request should exist");
+        assert_eq!(detail.status, "failed");
+        assert!(detail.failed_at.is_some());
+
+        // Verify error is valid FailureReason JSON
+        let error: crate::request::FailureReason =
+            serde_json::from_str(detail.error.as_ref().unwrap())
+                .expect("error should be valid FailureReason JSON");
+        assert!(matches!(
+            error,
+            crate::request::FailureReason::NonRetriableHttpStatus { status: 500, .. }
+        ));
+    }
+
+    #[sqlx::test]
+    async fn test_create_single_request_batch_shows_in_list_requests(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let request_id = uuid::Uuid::new_v4();
+        let _batch = manager
+            .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                request_id,
+                body: r#"{"input":"test"}"#.to_string(),
+                model: "gpt-4".to_string(),
+                base_url: "http://localhost:3001/ai".to_string(),
+                endpoint: "/v1/responses".to_string(),
+                completion_window: "0s".to_string(),
+                initial_state: "processing".to_string(),
+                api_key: None,
+                created_by: Some("user-abc".to_string()),
+            })
+            .await
+            .expect("create should succeed");
+
+        // Should appear in list_requests with require_service_tier
+        let result = manager
+            .list_requests(crate::request::ListRequestsFilter {
+                require_service_tier: true,
+                ..Default::default()
+            })
+            .await
+            .expect("list should succeed");
+
+        assert!(result.data.iter().any(|r| r.id == request_id));
+        let found = result.data.iter().find(|r| r.id == request_id).unwrap();
+        assert_eq!(found.service_tier, Some("priority".to_string()));
+        assert_eq!(found.batch_created_by, Some("user-abc".to_string()));
     }
 }

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2267,10 +2267,22 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 e
             ))
         })?;
-        let expires_at =
-            now + chrono::Duration::from_std(std_duration).unwrap_or(chrono::Duration::hours(24));
+        let expires_in = chrono::Duration::from_std(std_duration).map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Invalid completion_window duration '{}': {}",
+                input.completion_window,
+                e
+            ))
+        })?;
+        let expires_at = now.checked_add_signed(expires_in).ok_or_else(|| {
+            FusilladeError::ValidationError(format!(
+                "completion_window '{}' causes datetime overflow",
+                input.completion_window
+            ))
+        })?;
         let service_tier =
             crate::request::query::service_tier_from_completion_window(&input.completion_window);
+        let body_byte_size = input.body.len() as i64;
 
         let mut tx = pool
             .begin()
@@ -2288,10 +2300,10 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to create file: {}", e)))?;
 
-        // 2. Create template
+        // 2. Create template (with body_byte_size for accurate stats)
         sqlx::query(
-            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key)
-             VALUES ($1, $2, NULL, $3, 'POST', $4, $5, $6, $7)",
+            "INSERT INTO request_templates (id, file_id, custom_id, endpoint, method, path, body, model, api_key, body_byte_size)
+             VALUES ($1, $2, NULL, $3, 'POST', $4, $5, $6, $7, $8)",
         )
         .bind(template_id)
         .bind(file_id)
@@ -2300,6 +2312,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&input.body)
         .bind(&input.model)
         .bind(input.api_key.as_deref().unwrap_or(""))
+        .bind(body_byte_size)
         .execute(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to create template: {}", e)))?;
@@ -2315,16 +2328,17 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&input.completion_window)
         .bind(now)
         .bind(expires_at)
-        .bind(input.created_by.as_deref())
+        .bind(input.created_by.as_deref().unwrap_or(""))
         .execute(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to create batch: {}", e)))?;
 
         // 4. Create request with caller-specified ID and state.
         // When initial_state is 'processing', set daemon_id/claimed_at/started_at
-        // to satisfy the processing_fields_check constraint.
+        // to satisfy the processing_fields_check constraint. Uses a zero UUID as
+        // a sentinel daemon_id since no real daemon is processing the request.
         let (daemon_id, claimed_at, started_at) = if input.initial_state == "processing" {
-            (Some(input.request_id), Some(now), Some(now))
+            (Some(Uuid::nil()), Some(now), Some(now))
         } else {
             (None, None, None)
         };
@@ -3507,7 +3521,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let where_clause = format!(
             r#"
             WHERE (b.deleted_at IS NULL OR r.batch_id IS NULL)
-              AND ($1::text IS NULL OR b.created_by = $1 OR r.batch_id IS NULL)
+              AND ($1::text IS NULL OR b.created_by = $1)
               AND ($2::text IS NULL OR b.completion_window = $2)
               AND ($3::text IS NULL OR r.state = $3)
               AND ($4::text[] IS NULL OR r.model = ANY($4))

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -156,7 +156,7 @@ pub struct RequestDetail {
     pub failed_at: Option<DateTime<Utc>>,
     pub duration_ms: Option<f64>,
     pub response_status: Option<i16>,
-    /// `None` when the template has been purged (via file deletion + orphan purge).
+    /// `None` when the template has been purged (file soft-deleted + orphan purge).
     pub body: Option<String>,
     pub response_body: Option<String>,
     pub error: Option<String>,

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -15,6 +15,7 @@ const DEFAULT_LIMIT: i64 = 50;
 pub(crate) fn service_tier_from_completion_window(completion_window: &str) -> Option<&'static str> {
     match completion_window {
         "1h" => Some("flex"),
+        "0s" => Some("priority"),
         _ => None,
     }
 }
@@ -41,6 +42,9 @@ pub struct ListRequestsFilter {
     /// Batch-tier requests have NULL service_tier and are not filterable
     /// by this field (use `completion_window` instead).
     pub service_tier: Option<String>,
+    /// Only include requests that have a non-NULL service_tier.
+    /// Excludes standard batch requests (which have NULL service_tier).
+    pub require_service_tier: bool,
     /// Sort active requests (pending/claimed/processing) first
     pub active_first: bool,
     /// Number of rows to skip (offset pagination)
@@ -59,6 +63,7 @@ impl Default for ListRequestsFilter {
             created_after: None,
             created_before: None,
             service_tier: None,
+            require_service_tier: false,
             active_first: false,
             skip: 0,
             limit: DEFAULT_LIMIT,

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -74,7 +74,7 @@ impl Default for ListRequestsFilter {
 #[cfg_attr(feature = "postgres", derive(sqlx::FromRow))]
 pub struct RequestSummary {
     pub id: Uuid,
-    pub batch_id: Uuid,
+    pub batch_id: Option<Uuid>,
     pub model: String,
     #[cfg_attr(feature = "postgres", sqlx(rename = "state"))]
     pub status: String,
@@ -84,8 +84,9 @@ pub struct RequestSummary {
     pub duration_ms: Option<f64>,
     pub response_status: Option<i16>,
     pub service_tier: Option<String>,
-    /// Batch creator ID (user ID or org ID) — for ownership checks and email lookup
-    pub batch_created_by: String,
+    /// Batch or daemon creator ID — for ownership checks and email lookup.
+    /// NULL for daemon-managed requests that don't have a batch.
+    pub batch_created_by: Option<String>,
 }
 
 /// Internal row shape used previously when `list_requests` computed the total
@@ -122,7 +123,7 @@ mod deprecated_types {
         fn from(r: RequestSummaryWithCount) -> Self {
             Self {
                 id: r.id,
-                batch_id: r.batch_id,
+                batch_id: Some(r.batch_id),
                 model: r.model,
                 status: r.status,
                 created_at: r.created_at,
@@ -131,7 +132,7 @@ mod deprecated_types {
                 duration_ms: r.duration_ms,
                 response_status: r.response_status,
                 service_tier: r.service_tier,
-                batch_created_by: r.batch_created_by,
+                batch_created_by: Some(r.batch_created_by),
             }
         }
     }


### PR DESCRIPTION
## Summary

Add `create_single_request_batch` to the `Storage` trait — a dedicated method for creating single-request batches with a pre-generated request ID. This enables callers to know the request ID upfront without a DB round-trip.

### Changes

- **`CreateSingleRequestBatchInput`** — new input struct with `request_id`, `body`, `model`, `base_url`, `endpoint`, `completion_window`, `initial_state`, `api_key`, `created_by`
- **`create_single_request_batch`** — atomically creates file + template + batch + request in a single transaction. Supports caller-specified initial state (`pending` for daemon-processed, `processing` for externally-managed requests)
- **`RequestSummary` / `RequestDetail`** — `batch_id`, `batch_created_by`, `completion_window` are now `Option` to support batchless/single-request batches
- **`list_requests` / `get_request_detail`** — `LEFT JOIN batches` so daemon-managed and single-request-batch rows are included in results

### Usage by dwctl

dwctl uses this for all Open Responses API tracking:
- **Realtime** (`completion_window: "0s"`, `initial_state: "processing"`): batch created in background, onwards proxies immediately. Daemon won't claim these rows.
- **Flex** (`completion_window: "1h"`, `initial_state: "pending"`): batch created synchronously, daemon claims and processes.

## Test plan

- [x] Compiles clean
- [x] All 7 Open Responses execution modes pass end-to-end via dwctl
- [x] Daemon hot path (claim query) unchanged
- [x] Existing batch/request queries unaffected (LEFT JOIN is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)