### PR TITLE
feat: filter batches by completion window

### DIFF
--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -392,9 +392,11 @@ pub struct ListBatchesFilter {
     /// treated as terminal because cancel_batch sets both cancelling_at and
     /// cancelled_at atomically. Default false (pure chronological).
     pub active_first: bool,
-    /// Exclude batches with this completion window (e.g., "1h" to hide async batches).
-    /// When set, batches matching this window are filtered out.
-    pub exclude_completion_window: Option<String>,
+    /// Only return batches whose completion window matches any value in this
+    /// list (e.g., `["24h"]` for batch tier, `["1h"]` for flex, `["0s"]` for
+    /// realtime tracking rows). `None` disables the filter; `Some(vec![])`
+    /// matches no rows.
+    pub completion_windows: Option<Vec<String>>,
 }
 
 /// Items that can be yielded from a file upload stream

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -29,6 +29,10 @@ mod utils;
 /// Input for creating a single-request batch with a pre-generated request ID.
 #[derive(Debug, Clone)]
 pub struct CreateSingleRequestBatchInput {
+    /// Pre-generated batch UUID. Becomes the batch's primary key. Provided by
+    /// the caller so the same id can be set on outbound proxy headers (e.g.
+    /// `x-fusillade-batch-id`) before the row exists.
+    pub batch_id: Uuid,
     /// Pre-generated request UUID. Becomes the request's primary key.
     pub request_id: Uuid,
     /// Request body (JSON string).

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -29,10 +29,11 @@ mod utils;
 /// Input for creating a single-request batch with a pre-generated request ID.
 #[derive(Debug, Clone)]
 pub struct CreateSingleRequestBatchInput {
-    /// Pre-generated batch UUID. Becomes the batch's primary key. Provided by
-    /// the caller so the same id can be set on outbound proxy headers (e.g.
-    /// `x-fusillade-batch-id`) before the row exists.
-    pub batch_id: Uuid,
+    /// Optional pre-generated batch UUID. When `Some`, becomes the batch's
+    /// primary key — useful when the caller needs to attach the id to
+    /// outbound proxy headers (e.g. `x-fusillade-batch-id`) before the row
+    /// exists. When `None`, a fresh UUID is generated internally.
+    pub batch_id: Option<Uuid>,
     /// Pre-generated request UUID. Becomes the request's primary key.
     pub request_id: Uuid,
     /// Request body (JSON string).

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2258,7 +2258,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let now = Utc::now();
         let template_id = Uuid::new_v4();
         let file_id = Uuid::new_v4();
-        let batch_id = input.batch_id;
+        let batch_id = input.batch_id.unwrap_or_else(Uuid::new_v4);
 
         let std_duration = humantime::parse_duration(&input.completion_window).map_err(|e| {
             FusilladeError::Other(anyhow!(
@@ -13193,7 +13193,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13233,7 +13233,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13267,7 +13267,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13300,7 +13300,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13347,7 +13347,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13395,7 +13395,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
-                batch_id: uuid::Uuid::new_v4(),
+                batch_id: None,
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2258,7 +2258,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let now = Utc::now();
         let template_id = Uuid::new_v4();
         let file_id = Uuid::new_v4();
-        let batch_id = Uuid::new_v4();
+        let batch_id = input.batch_id;
 
         let std_duration = humantime::parse_duration(&input.completion_window).map_err(|e| {
             FusilladeError::Other(anyhow!(
@@ -2671,7 +2671,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             created_after,
             created_before,
             active_first,
-            exclude_completion_window,
+            completion_windows,
         } = filter;
         let limit = limit.unwrap_or(100);
 
@@ -2878,10 +2878,13 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             }
         }
 
-        // Exclude batches with a specific completion window (e.g., hide async batches)
-        if let Some(ref exclude_window) = exclude_completion_window {
-            query_builder.push(" AND b.completion_window != ");
-            query_builder.push_bind(exclude_window.as_str());
+        // Restrict to a specific set of completion windows (e.g., ["24h"] for
+        // batch tier, ["1h"] for flex, ["0s"] for realtime tracking rows).
+        // Uses idx_batches_completion_window. An empty vec returns no rows.
+        if let Some(ref windows) = completion_windows {
+            query_builder.push(" AND b.completion_window = ANY(");
+            query_builder.push_bind(windows.as_slice());
+            query_builder.push(")");
         }
 
         // ORDER BY: when active_first is enabled, sort by the `priority` column
@@ -12502,7 +12505,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_list_batches_exclude_completion_window(pool: sqlx::PgPool) {
+    async fn test_list_batches_completion_windows(pool: sqlx::PgPool) {
         let http_client = Arc::new(MockHttpClient::new());
         let manager = PostgresRequestManager::with_client(
             TestDbPools::new(pool.clone()).await.unwrap(),
@@ -12557,10 +12560,10 @@ mod tests {
             .await
             .unwrap();
 
-        // Exclude 24h — should only return the 1h batch
+        // Restrict to 1h — should only return the 1h batch
         let result = manager
             .list_batches(crate::batch::ListBatchesFilter {
-                exclude_completion_window: Some("24h".to_string()),
+                completion_windows: Some(vec!["1h".to_string()]),
                 ..Default::default()
             })
             .await
@@ -12570,10 +12573,10 @@ mod tests {
         assert_eq!(result[0].id, batch_1h.id);
         assert_eq!(result[0].completion_window, "1h");
 
-        // Exclude 1h — should only return the 24h batch
+        // Restrict to 24h — should only return the 24h batch
         let result = manager
             .list_batches(crate::batch::ListBatchesFilter {
-                exclude_completion_window: Some("1h".to_string()),
+                completion_windows: Some(vec!["24h".to_string()]),
                 ..Default::default()
             })
             .await
@@ -12582,13 +12585,35 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].completion_window, "24h");
 
-        // No exclusion — both returned
+        // Allow both windows — both returned
+        let result = manager
+            .list_batches(crate::batch::ListBatchesFilter {
+                completion_windows: Some(vec!["1h".to_string(), "24h".to_string()]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+
+        // No filter — both returned
         let result = manager
             .list_batches(crate::batch::ListBatchesFilter::default())
             .await
             .unwrap();
 
         assert_eq!(result.len(), 2);
+
+        // Empty vec — matches nothing
+        let result = manager
+            .list_batches(crate::batch::ListBatchesFilter {
+                completion_windows: Some(vec![]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 0);
     }
 
     // =========================================================================
@@ -13168,6 +13193,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13207,6 +13233,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"model":"gpt-4","input":"hi"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13240,6 +13267,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13272,6 +13300,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13318,6 +13347,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),
@@ -13365,6 +13395,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let _batch = manager
             .create_single_request_batch(crate::manager::CreateSingleRequestBatchInput {
+                batch_id: uuid::Uuid::new_v4(),
                 request_id,
                 body: r#"{"input":"test"}"#.to_string(),
                 model: "gpt-4".to_string(),


### PR DESCRIPTION
#  Fusillade changes

  - src/batch/mod.rs — ListBatchesFilter.exclude_completion_window: Option<String> replaced with positive completion_windows: Option<Vec<String>>. None = no filter, Some(vec![]) = matches nothing.
  - src/manager/postgres.rs — list_batches SQL now uses b.completion_window = ANY($n) (still hits the existing idx_batches_completion_window partial index, no new migrations).
  - src/manager/mod.rs — CreateSingleRequestBatchInput gains a batch_id: Uuid field. Caller-supplied so the same id can be set on outbound proxy headers before the row is inserted.
  - src/manager/postgres.rs — create_single_request_batch uses input.batch_id instead of generating one internally; six in-file test sites updated; the test_list_batches_exclude_completion_window test renamed to
  test_list_batches_completion_windows and expanded to cover single, multi, none, and empty-vec cases.

  Breaking: both the ListBatchesFilter rename and the new required batch_id field warrant a major version bump on the next release.