### PR TITLE
fix: filter service_tier in queue monitoring query

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -13,6 +13,7 @@ use crate::http::HttpClient;
 use crate::request::{
     AnyRequest, CascadeTargetState, Claimed, CreateDaemonRequestInput, DaemonId,
     ListRequestsFilter, Request, RequestDetail, RequestId, RequestListResult, RequestState,
+    ServiceTierFilter,
 };
 use async_trait::async_trait;
 use futures::stream::Stream;
@@ -313,6 +314,9 @@ pub trait Storage: Send + Sync {
     /// - `states`: request states to include (e.g. `["pending"]`, or
     ///   `["pending","claimed","processing"]`).
     /// - `model_filter`: optional model whitelist (empty = all).
+    /// - `service_tier_filter`: filter on `service_tier`. `Any` (default) applies
+    ///   no filter; `Include`/`Exclude` use `Option<String>` where `None`
+    ///   represents the batch tier (`service_tier IS NULL`).
     /// - `strict`: bool. For critical/sensitive operations, set `true` to
     ///   use the write pool and avoid read lags.
     ///
@@ -324,6 +328,7 @@ pub trait Storage: Send + Sync {
         windows: &[(String, Option<i64>, i64)],
         states: &[String],
         model_filter: &[String],
+        service_tier_filter: &ServiceTierFilter,
         strict: bool,
     ) -> Result<HashMap<String, HashMap<String, i64>>>;
     ///

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -38,6 +38,7 @@ use crate::http::HttpClient;
 use crate::request::{
     Canceled, CascadeTargetState, Claimed, Completed, CreateDaemonRequestInput, DaemonId, Failed,
     FailureReason, Pending, Processing, Request, RequestData, RequestId, RequestState,
+    ServiceTierFilter,
 };
 
 use super::DaemonExecutor;
@@ -733,6 +734,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         windows: &[(String, Option<i64>, i64)], // (label, start_secs, end_secs)
         states: &[String], // e.g. ["pending"] or ["pending","claimed","processing"]
         model_filter: &[String], // empty = all models
+        service_tier_filter: &ServiceTierFilter,
         strict: bool,
     ) -> Result<HashMap<String, HashMap<String, i64>>> {
         if windows.is_empty() || states.is_empty() {
@@ -761,6 +763,22 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             ends.push(*end);
         }
 
+        // Translate the service_tier filter into (named_tiers, include_null,
+        // mode) where mode is 'any' | 'include' | 'exclude'. The SQL branches
+        // on $9 so each variant short-circuits to a single predicate.
+        let (tier_names, tier_include_null, tier_mode): (Vec<String>, bool, &str) =
+            match service_tier_filter {
+                ServiceTierFilter::Any => (Vec::new(), true, "any"),
+                ServiceTierFilter::Include(tiers) => {
+                    let (names, has_null) = ServiceTierFilter::split(tiers);
+                    (names, has_null, "include")
+                }
+                ServiceTierFilter::Exclude(tiers) => {
+                    let (names, has_null) = ServiceTierFilter::split(tiers);
+                    (names, has_null, "exclude")
+                }
+            };
+
         let pool = if strict {
             self.pools.write()
         } else {
@@ -786,6 +804,17 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             AND r.template_id IS NOT NULL
             AND b.cancelling_at IS NULL
             AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
+            AND (
+                $9 = 'any'
+                OR ($9 = 'include' AND (
+                    (r.service_tier IS NOT NULL AND r.service_tier = ANY($7))
+                    OR ($8 AND r.service_tier IS NULL)
+                ))
+                OR ($9 = 'exclude' AND (
+                    (r.service_tier IS NULL AND NOT $8)
+                    OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($7))
+                ))
+            )
             GROUP BY r.model, w.label
             "#,
         )
@@ -795,6 +824,9 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&ends)
         .bind(states)
         .bind(model_filter)
+        .bind(&tier_names)
+        .bind(tier_include_null)
+        .bind(tier_mode)
         .fetch_all(pool)
         .await
         .map_err(|e| {
@@ -11199,7 +11231,13 @@ mod tests {
         let model_filter: Vec<String> = vec![];
 
         let counts = manager
-            .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, false)
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                false,
+            )
             .await
             .unwrap();
 
@@ -11218,6 +11256,7 @@ mod tests {
                 &[("1h:4h".to_string(), Some(3600), 14_400)],
                 &states,
                 &model_filter,
+                &ServiceTierFilter::Any,
                 false,
             )
             .await
@@ -11231,6 +11270,7 @@ mod tests {
                 &[("bad".to_string(), Some(7200), 3600)],
                 &states,
                 &model_filter,
+                &ServiceTierFilter::Any,
                 false,
             )
             .await
@@ -11255,6 +11295,7 @@ mod tests {
                 &[("1h".to_string(), None, 3600)],
                 &states,
                 &model_filter,
+                &ServiceTierFilter::Any,
                 false,
             )
             .await
@@ -11266,6 +11307,7 @@ mod tests {
                 &[("1h".to_string(), Some(0), 3600)],
                 &states,
                 &model_filter,
+                &ServiceTierFilter::Any,
                 false,
             )
             .await
@@ -11359,7 +11401,13 @@ mod tests {
         let model_filter = vec!["model-a".to_string()];
 
         let counts = manager
-            .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, false)
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                false,
+            )
             .await
             .unwrap();
 
@@ -11372,7 +11420,13 @@ mod tests {
         let model_filter: Vec<String> = vec![];
 
         let counts_all = manager
-            .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, false)
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                false,
+            )
             .await
             .unwrap();
 
@@ -11389,7 +11443,13 @@ mod tests {
         .unwrap();
 
         let counts_cancelled = manager
-            .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, false)
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                false,
+            )
             .await
             .unwrap();
 
@@ -11407,6 +11467,7 @@ mod tests {
                 &[],
                 &["pending".to_string()],
                 &[],
+                &ServiceTierFilter::Any,
                 false,
             )
             .await
@@ -11418,6 +11479,154 @@ mod tests {
                 &[("1h".to_string(), None, 3600)],
                 &[],
                 &[],
+                &ServiceTierFilter::Any,
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(counts.is_empty());
+    }
+
+    #[sqlx::test]
+    async fn test_pending_request_counts_service_tier_filter(pool: sqlx::PgPool) {
+        use chrono::Duration;
+
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        // Three batches for the same model with different completion windows,
+        // which derive different service_tier values:
+        //   "24h" → NULL (batch tier)
+        //   "1h"  → "flex"
+        //   "0s"  → "priority"
+        let mut batch_ids = Vec::new();
+        for (label, completion_window) in [("batch", "24h"), ("flex", "1h"), ("priority", "0s")] {
+            let file_id = manager
+                .create_file(
+                    format!("file-{label}"),
+                    None,
+                    vec![RequestTemplateInput {
+                        custom_id: Some(label.to_string()),
+                        endpoint: "/v1/chat/completions".to_string(),
+                        method: "POST".to_string(),
+                        path: "/v1/chat/completions".to_string(),
+                        body: r#"{"input":"x"}"#.to_string(),
+                        model: "model-a".to_string(),
+                        api_key: "k".to_string(),
+                    }],
+                )
+                .await
+                .unwrap();
+
+            let batch = manager
+                .create_batch(BatchInput {
+                    file_id,
+                    endpoint: "/v1/chat/completions".to_string(),
+                    completion_window: completion_window.to_string(),
+                    metadata: None,
+                    created_by: None,
+                    api_key_id: None,
+                    api_key: None,
+                    total_requests: None,
+                })
+                .await
+                .unwrap();
+            batch_ids.push(batch.id);
+        }
+
+        // Pin all expires_at to a known future time so the window predicate
+        // matches deterministically and is independent of completion_window.
+        let now = Utc::now();
+        for batch_id in &batch_ids {
+            sqlx::query!(
+                "UPDATE batches SET expires_at = $1 WHERE id = $2",
+                now + Duration::minutes(30),
+                **batch_id as Uuid
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let windows = vec![("1h".to_string(), None, 3600)];
+        let states = vec!["pending".to_string()];
+        let model_filter: Vec<String> = vec![];
+
+        // Any: all three rows counted.
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 3);
+
+        // Exclude("priority"): batch + flex.
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Exclude(vec![Some("priority".to_string())]),
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
+
+        // Include only batch tier (None represents NULL).
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Include(vec![None]),
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 1);
+
+        // Include batch + flex.
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Include(vec![None, Some("flex".to_string())]),
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
+
+        // Exclude batch tier (None represents NULL): flex + priority.
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Exclude(vec![None]),
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
+
+        // Empty Include matches nothing.
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Include(vec![]),
                 false,
             )
             .await

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -14,6 +14,7 @@ pub mod types;
 pub use query::RequestSummaryWithCount;
 pub use query::{
     CreateDaemonRequestInput, ListRequestsFilter, RequestDetail, RequestListResult, RequestSummary,
+    ServiceTierFilter,
 };
 pub use transitions::CancellationReason;
 pub use types::*;

--- a/src/request/query.rs
+++ b/src/request/query.rs
@@ -20,6 +20,38 @@ pub(crate) fn service_tier_from_completion_window(completion_window: &str) -> Op
     }
 }
 
+/// Filter on `service_tier`.
+///
+/// `None` in the inner vec represents the batch tier (`service_tier IS NULL`);
+/// named strings match specific tier values such as `"flex"` or `"priority"`.
+///
+/// `Default` is `Any` — no filter applied.
+#[derive(Debug, Clone, Default)]
+pub enum ServiceTierFilter {
+    /// No filter — match all tiers including batch (NULL).
+    #[default]
+    Any,
+    /// Match only rows whose tier is in this set. Empty matches nothing.
+    Include(Vec<Option<String>>),
+    /// Match all tiers except those in this set.
+    Exclude(Vec<Option<String>>),
+}
+
+impl ServiceTierFilter {
+    /// Split a list of `Option<String>` tiers into (named_tiers, includes_null).
+    pub(crate) fn split(tiers: &[Option<String>]) -> (Vec<String>, bool) {
+        let mut names = Vec::with_capacity(tiers.len());
+        let mut has_null = false;
+        for t in tiers {
+            match t {
+                Some(s) => names.push(s.clone()),
+                None => has_null = true,
+            }
+        }
+        (names, has_null)
+    }
+}
+
 /// Filter parameters for listing requests across batches.
 #[derive(Debug, Clone)]
 pub struct ListRequestsFilter {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,7 +4,7 @@ use fusillade::daemon::{DaemonConfig, ModelEscalationConfig, default_should_retr
 use fusillade::http::{HttpResponse, MockHttpClient};
 use fusillade::manager::postgres::PostgresRequestManager;
 use fusillade::manager::{DaemonExecutor, Storage};
-use fusillade::request::ListRequestsFilter;
+use fusillade::request::{ListRequestsFilter, ServiceTierFilter};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -2357,6 +2357,7 @@ mod queue_counts {
                 ],
                 &["pending".to_string()],
                 &[],
+                &ServiceTierFilter::Any,
                 false,
             )
             .await


### PR DESCRIPTION
 **Changes** — adds the filter type, threads it through the trait + SQL, plus a new test.                                                                                                      
  
  - `src/request/query.rs:23-50` — new ServiceTierFilter enum (Any / Include(Vec<Option<String>>) / Exclude(...)) with a split helper. None in the inner vec represents the batch tier (NULL).  
  - `src/request/mod.rs` — re-export it.                            
  - `src/manager/mod.rs:295-336` — trait signature gets a new service_tier_filter: &ServiceTierFilter parameter, with doc updates.                                                              
  - `src/manager/postgres.rs:731-832` — implementation translates the filter into (tier_names, include_null, mode) bound as $7/$8/$9. The SQL branches on $9, so each variant short-circuits to 
  a single predicate; Any becomes a constant true.                                                                                                                                            
  - `src/manager/postgres.rs:11460+` — new test test_pending_request_counts_service_tier_filter covers Any, Exclude(priority), Include([None]), Include([None, flex]), Exclude([None]), and     
  empty Include. All four pending_request_counts tests pass.                                                                                                                                  
  - `tests/integration.rs:7,2360` — pass &ServiceTierFilter::Any at the existing call site.
                                                                                              