### PR TITLE
fix: accept status code in fail_request

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -453,11 +453,16 @@ pub trait Storage: Send + Sync {
         status_code: u16,
     ) -> Result<()>;
 
-    /// Fail a processing request with an error message.
+    /// Fail a processing request with an error message and HTTP status code.
     ///
     /// Transitions the request from "processing" to "failed" and stores the
-    /// error message as a JSON object.
-    async fn fail_request(&self, request_id: RequestId, error: &str) -> Result<()>;
+    /// error as a `NonRetriableHttpStatus` JSON object with the given status code.
+    async fn fail_request(
+        &self,
+        request_id: RequestId,
+        error: &str,
+        status_code: u16,
+    ) -> Result<()>;
 }
 
 /// Daemon lifecycle persistence.

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3803,11 +3803,16 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         Ok(())
     }
 
-    async fn fail_request(&self, request_id: RequestId, error: &str) -> Result<()> {
+    async fn fail_request(
+        &self,
+        request_id: RequestId,
+        error: &str,
+        status_code: u16,
+    ) -> Result<()> {
         let pool = self.pools.write();
 
         let reason = FailureReason::NonRetriableHttpStatus {
-            status: 500,
+            status: status_code,
             body: error.to_string(),
         };
         let error_json = serde_json::to_string(&reason).map_err(|e| {
@@ -13572,7 +13577,11 @@ mod tests {
 
         // Fail the request
         manager
-            .fail_request(crate::request::RequestId(request_id), "upstream timeout")
+            .fail_request(
+                crate::request::RequestId(request_id),
+                "upstream timeout",
+                504,
+            )
             .await
             .expect("fail should succeed");
 
@@ -13589,7 +13598,7 @@ mod tests {
                 .expect("error should be valid FailureReason JSON");
         assert!(matches!(
             error,
-            crate::request::FailureReason::NonRetriableHttpStatus { status: 500, .. }
+            crate::request::FailureReason::NonRetriableHttpStatus { status: 504, .. }
         ));
     }
 


### PR DESCRIPTION
## Summary
- `fail_request` now takes a `status_code: u16` parameter instead of hardcoding 500
- The actual upstream HTTP status is preserved in the `NonRetriableHttpStatus` failure reason
- Previously a 403 from upstream would be stored as 500, causing callers (dwctl responses API) to lose the real error code

## Test plan
- [ ] `test_create_single_request_batch_fail_lifecycle` updated to pass 504 and assert it
- [ ] `cargo test` passes
- [ ] Companion dwctl PR: uses `complete_request` to avoid this path entirely, but this fix ensures future `fail_request` callers preserve status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)