### PR TITLE
feat: add response_steps storage layer for multi-step responses

### DIFF
--- a/migrations/20260428000000_add_response_steps.down.sql
+++ b/migrations/20260428000000_add_response_steps.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS response_steps_parent;
+DROP INDEX IF EXISTS response_steps_prev;
+DROP INDEX IF EXISTS response_steps_chain;
+DROP TABLE IF EXISTS response_steps;

--- a/migrations/20260428000000_add_response_steps.up.sql
+++ b/migrations/20260428000000_add_response_steps.up.sql
@@ -18,11 +18,17 @@ CREATE TABLE IF NOT EXISTS response_steps (
     -- Linear predecessor within a single chain (NULL = first step in its
     -- scope). Scope is (request_id, parent_step_id): the chain restarts
     -- inside each nested sub-loop.
-    prev_step_id    UUID NULL REFERENCES response_steps(id),
+    --
+    -- ON DELETE CASCADE so a parent-row delete (or a manual single-row
+    -- delete in the chain) does not leave dangling pointers. The cascade
+    -- from `requests` already deletes every step in one statement, but
+    -- being explicit here keeps individual-step deletes safe too.
+    prev_step_id    UUID NULL REFERENCES response_steps(id) ON DELETE CASCADE,
 
     -- Nesting pointer for sub-agent loops (NULL = top-level step in the
-    -- user-visible response).
-    parent_step_id  UUID NULL REFERENCES response_steps(id),
+    -- user-visible response). ON DELETE CASCADE for the same reason as
+    -- prev_step_id.
+    parent_step_id  UUID NULL REFERENCES response_steps(id) ON DELETE CASCADE,
 
     step_kind       TEXT NOT NULL,
 
@@ -58,6 +64,61 @@ CREATE TABLE IF NOT EXISTS response_steps (
     CONSTRAINT response_steps_state_check
         CHECK (state IN ('pending', 'processing',
                          'completed', 'failed', 'canceled')),
+
+    -- State field-presence invariants, mirroring the `requests` table.
+    -- These backstop partial-update bugs that would otherwise leave a row
+    -- in an inconsistent shape (e.g., `completed` with no
+    -- `response_payload`).
+    CONSTRAINT response_steps_pending_fields_check CHECK (
+        state <> 'pending' OR (
+            started_at IS NULL
+            AND completed_at IS NULL
+            AND failed_at IS NULL
+            AND canceled_at IS NULL
+            AND response_payload IS NULL
+            AND error IS NULL
+        )
+    ),
+    CONSTRAINT response_steps_processing_fields_check CHECK (
+        state <> 'processing' OR (
+            started_at IS NOT NULL
+            AND completed_at IS NULL
+            AND failed_at IS NULL
+            AND canceled_at IS NULL
+            AND response_payload IS NULL
+            AND error IS NULL
+        )
+    ),
+    CONSTRAINT response_steps_completed_fields_check CHECK (
+        state <> 'completed' OR (
+            started_at IS NOT NULL
+            AND completed_at IS NOT NULL
+            AND failed_at IS NULL
+            AND canceled_at IS NULL
+            AND response_payload IS NOT NULL
+            AND error IS NULL
+        )
+    ),
+    -- `failed` and `canceled` are reachable from either `pending` or
+    -- `processing`, so `started_at` may be NULL on these rows. We do not
+    -- require it.
+    CONSTRAINT response_steps_failed_fields_check CHECK (
+        state <> 'failed' OR (
+            completed_at IS NULL
+            AND failed_at IS NOT NULL
+            AND canceled_at IS NULL
+            AND response_payload IS NULL
+            AND error IS NOT NULL
+        )
+    ),
+    CONSTRAINT response_steps_canceled_fields_check CHECK (
+        state <> 'canceled' OR (
+            completed_at IS NULL
+            AND failed_at IS NULL
+            AND canceled_at IS NOT NULL
+            AND response_payload IS NULL
+        )
+    ),
 
     -- Idempotency safety net for crash recovery: a re-running transition
     -- function must not produce duplicate successor rows. Recovery

--- a/migrations/20260428000000_add_response_steps.up.sql
+++ b/migrations/20260428000000_add_response_steps.up.sql
@@ -1,0 +1,92 @@
+-- Add response_steps table for multi-step Open Responses orchestration.
+--
+-- Each row is a discrete unit of work in a multi-step response: either a
+-- model_call (upstream LLM invocation) or a tool_call (server-side tool
+-- execution). Rows are linearly chained per (request_id, parent_step_id)
+-- via prev_step_id, with parent_step_id pointing at the enclosing
+-- tool_call step for nested sub-agent loops (NULL for top-level steps).
+--
+-- See fusillade/docs/plans/2026-04-28-multi-step-responses.md.
+--
+-- Pre-deploy: a fresh table — no large-table locking concerns. CREATE
+-- INDEX CONCURRENTLY is not required.
+
+CREATE TABLE IF NOT EXISTS response_steps (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    request_id      UUID NOT NULL REFERENCES requests(id) ON DELETE CASCADE,
+
+    -- Linear predecessor within a single chain (NULL = first step in its
+    -- scope). Scope is (request_id, parent_step_id): the chain restarts
+    -- inside each nested sub-loop.
+    prev_step_id    UUID NULL REFERENCES response_steps(id),
+
+    -- Nesting pointer for sub-agent loops (NULL = top-level step in the
+    -- user-visible response).
+    parent_step_id  UUID NULL REFERENCES response_steps(id),
+
+    step_kind       TEXT NOT NULL,
+
+    -- Monotonic per request_id, global across nesting levels. Doubles as
+    -- the Last-Event-ID stream cursor for top-level events.
+    step_sequence   BIGINT NOT NULL,
+
+    -- Step inputs (instructions only; full HTTP body is assembled at
+    -- fire time from the chain walk, not denormalized into each row).
+    request_payload JSONB NOT NULL,
+
+    -- Step output (NULL until the step reaches a terminal state).
+    response_payload JSONB NULL,
+
+    -- State machine — mirrors fusillade.requests state values. No claim
+    -- columns: serialized access is provided by the parent requests row's
+    -- lease (held by onwards inline or by a fusillade daemon worker).
+    state           TEXT NOT NULL DEFAULT 'pending',
+
+    started_at      TIMESTAMPTZ NULL,
+    completed_at    TIMESTAMPTZ NULL,
+    failed_at       TIMESTAMPTZ NULL,
+    canceled_at     TIMESTAMPTZ NULL,
+    retry_attempt   INT NOT NULL DEFAULT 0,
+    error           JSONB NULL,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT response_steps_kind_check
+        CHECK (step_kind IN ('model_call', 'tool_call')),
+
+    CONSTRAINT response_steps_state_check
+        CHECK (state IN ('pending', 'processing',
+                         'completed', 'failed', 'canceled')),
+
+    -- Idempotency safety net for crash recovery: a re-running transition
+    -- function must not produce duplicate successor rows. Recovery
+    -- primarily relies on a chain walk that identifies the existing
+    -- frontier; this constraint backstops any race.
+    --
+    -- NULLS NOT DISTINCT (PG15+) is required because both
+    -- `parent_step_id` (NULL = top-level) and `prev_step_id` (NULL =
+    -- first in scope) are nullable. With the default NULLS DISTINCT
+    -- behavior, two `(request_id, NULL, NULL, 'model_call')` rows
+    -- would not conflict and the safety net would be void.
+    CONSTRAINT response_steps_chain_unique
+        UNIQUE NULLS NOT DISTINCT (request_id, parent_step_id, prev_step_id, step_kind)
+);
+
+-- Chain walk for a given scope (top-level or sub-loop): the
+-- (request_id, parent_step_id) pair identifies the chain, step_sequence
+-- orders it. Postgres treats NULL parent_step_id as its own group.
+CREATE INDEX IF NOT EXISTS response_steps_chain
+    ON response_steps (request_id, parent_step_id, step_sequence);
+
+-- Predecessor lookup: find a step's successor (or detect leaf during
+-- crash recovery).
+CREATE INDEX IF NOT EXISTS response_steps_prev
+    ON response_steps (prev_step_id)
+    WHERE prev_step_id IS NOT NULL;
+
+-- Sub-loop traversal: gather all sub-steps of a given parent step
+-- (e.g., when rendering the dashboard's expandable sub-agent tree).
+CREATE INDEX IF NOT EXISTS response_steps_parent
+    ON response_steps (parent_step_id)
+    WHERE parent_step_id IS NOT NULL;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -16,6 +16,7 @@ use crate::batch::BatchId;
 use crate::error::Result;
 use crate::http::{HttpClient, HttpResponse};
 use crate::manager::{DaemonStorage, Storage};
+use crate::processor::{DefaultRequestProcessor, RequestProcessor};
 use crate::request::{DaemonId, RequestCompletionResult};
 
 pub mod transitions;
@@ -314,6 +315,12 @@ where
     storage: Arc<S>,
     http_client: Arc<H>,
     config: DaemonConfig,
+    /// Per-claim processing hook. Defaults to [`DefaultRequestProcessor`],
+    /// which preserves the existing fire-and-store pipeline byte-for-byte.
+    /// Override via [`Daemon::with_processor`] to inject custom orchestration
+    /// (e.g. multi-step Open Responses loops) without changing any other
+    /// daemon behavior.
+    processor: Arc<dyn RequestProcessor<S, H>>,
     requests_in_flight: Arc<dashmap::DashMap<String, AtomicUsize>>,
     /// Per-user in-flight request counts across all models, used to prioritise
     /// users with fewer active requests during claim (per-user fair scheduling).
@@ -334,6 +341,10 @@ where
     H: HttpClient + 'static,
 {
     /// Create a new daemon.
+    ///
+    /// Uses [`DefaultRequestProcessor`] for per-claim processing, preserving
+    /// today's pipeline behavior. To inject custom orchestration, chain
+    /// [`Daemon::with_processor`] after this.
     pub fn new(
         storage: Arc<S>,
         http_client: Arc<H>,
@@ -345,6 +356,7 @@ where
             storage,
             http_client,
             config,
+            processor: Arc::new(DefaultRequestProcessor),
             requests_in_flight: Arc::new(dashmap::DashMap::new()),
             user_requests_in_flight: Arc::new(dashmap::DashMap::new()),
             user_throughput: Arc::new(dashmap::DashMap::new()),
@@ -353,6 +365,24 @@ where
             shutdown_token,
             cancellation_tokens: Arc::new(dashmap::DashMap::new()),
         }
+    }
+
+    /// Override the per-claim processing hook.
+    ///
+    /// Returns `self` for chained construction:
+    ///
+    /// ```ignore
+    /// let daemon = Daemon::new(storage, http, config, shutdown)
+    ///     .with_processor(Arc::new(my_custom_processor));
+    /// ```
+    ///
+    /// The provided processor is invoked once per claimed request in place
+    /// of the default fire-and-store path. The daemon continues to own
+    /// metrics, cancellation token plumbing, retry persistence, and the
+    /// outer processing span.
+    pub fn with_processor(mut self, processor: Arc<dyn RequestProcessor<S, H>>) -> Self {
+        self.processor = processor;
+        self
     }
 
     /// Run the daemon loop.
@@ -874,6 +904,7 @@ where
                         .unwrap_or_default();
                     let storage = self.storage.clone();
                     let http_client = (*self.http_client).clone();
+                    let processor = self.processor.clone();
                     let retry_config = (&self.config).into();
                     let requests_in_flight = self.requests_in_flight.clone();
                     let user_throughput = self.user_throughput.clone();
@@ -949,30 +980,19 @@ where
                             }
                         });
 
-                        // Duration span covering the claimed state (from claim to process start)
-                        let retry_attempt = request.state.retry_attempt;
-                        let processing = async {
-                            tracing::debug!("Sending batch request to inference endpoint");
-                            request.process(
-                                http_client,
-                                storage.as_ref()
-                            ).await
-                        }.instrument(tracing::info_span!(
-                            "fusillade.state.claimed",
-                            otel.name = "fusillade.state.claimed",
-                            request_id = %request_id,
-                            daemon_id = %daemon_id,
-                            retry_attempt,
-                        )).await?;
+                        // Capture retry attempt and batch expiry before moving the
+                        // request into the processor. retry_attempt is preserved
+                        // unchanged across Claimed -> Processing -> terminal, so a
+                        // single capture suffices for downstream metrics.
+                        let retry_attempt_at_completion = request.state.retry_attempt;
+                        let batch_expires_at = request.state.batch_expires_at;
 
-                        // Capture retry attempt count before completion (not preserved in Completed state)
-                        let retry_attempt_at_completion = processing.state.retry_attempt;
-                        // Capture batch expiry time for SLA missed completion tracking
-                        let batch_expires_at = processing.state.batch_expires_at;
-
-                        // Duration span covering the processing state (HTTP in-flight)
-                        let completion_result = async {
-                            let cancellation = async {
+                        // Build the cancellation future the daemon owns. The
+                        // processor observes this without needing to know about
+                        // the underlying tokens — keeping shutdown ordering a
+                        // daemon concern.
+                        let cancellation: crate::processor::CancellationFuture =
+                            Box::pin(async move {
                                 tokio::select! {
                                     _ = batch_cancellation_token.cancelled() => {
                                         crate::request::transitions::CancellationReason::User
@@ -981,17 +1001,22 @@ where
                                         crate::request::transitions::CancellationReason::Shutdown
                                     }
                                 }
-                            };
+                            });
 
-                            processing.complete(storage.as_ref(), |response| {
-                                (should_retry)(response)
-                            }, cancellation).await
-                        }.instrument(tracing::info_span!(
-                            "fusillade.state.processing",
-                            otel.name = "fusillade.state.processing",
-                            request_id = %request_id,
-                            retry_attempt = retry_attempt_at_completion
-                        )).await;
+                        // Hand the per-claim work to the processor. The default
+                        // impl emits the same fusillade.state.claimed and
+                        // fusillade.state.processing spans the daemon used to
+                        // emit inline, so observability is unchanged for the
+                        // batch path.
+                        let completion_result = processor
+                            .process(
+                                request,
+                                http_client,
+                                storage.as_ref(),
+                                should_retry.clone(),
+                                cancellation,
+                            )
+                            .await;
 
                         match completion_result {
                             Ok(RequestCompletionResult::Completed(completed)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod daemon;
 pub mod error;
 pub mod http;
 pub mod manager;
+pub mod processor;
 pub mod request;
 pub mod response_step;
 
@@ -23,6 +24,7 @@ pub use manager::postgres::{PoolProvider, PostgresRequestManager, TestDbPools};
 #[cfg(feature = "postgres")]
 pub use manager::response_step::PostgresResponseStepManager;
 pub use manager::{CreateSingleRequestBatchInput, DaemonExecutor, Storage};
+pub use processor::{CancellationFuture, DefaultRequestProcessor, RequestProcessor, ShouldRetry};
 pub use request::*;
 pub use response_step::{
     CreateStepInput, ResponseStep, ResponseStepStore, StepId, StepKind, StepState,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod error;
 pub mod http;
 pub mod manager;
 pub mod request;
+pub mod response_step;
 
 // Re-export commonly used types
 pub use batch::*;
@@ -19,8 +20,13 @@ pub use daemon::{Daemon, DaemonConfig, ModelEscalationConfig};
 pub use error::{FusilladeError, Result};
 pub use http::{HttpClient, HttpResponse, MockHttpClient, ReqwestHttpClient, StreamReassembler};
 pub use manager::postgres::{PoolProvider, PostgresRequestManager, TestDbPools};
+#[cfg(feature = "postgres")]
+pub use manager::response_step::PostgresResponseStepManager;
 pub use manager::{CreateSingleRequestBatchInput, DaemonExecutor, Storage};
 pub use request::*;
+pub use response_step::{
+    CreateStepInput, ResponseStep, ResponseStepStore, StepId, StepKind, StepState,
+};
 
 /// Get the fusillade database migrator
 ///

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -25,6 +25,8 @@ use uuid::Uuid;
 
 #[cfg(feature = "postgres")]
 pub mod postgres;
+#[cfg(feature = "postgres")]
+pub mod response_step;
 mod utils;
 
 /// Input for creating a single-request batch with a pre-generated request ID.

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -88,6 +88,12 @@ pub struct PostgresRequestManager<P: PoolProvider, H: HttpClient> {
     config: DaemonConfig,
     download_buffer_size: usize,
     batch_insert_strategy: BatchInsertStrategy,
+    /// Optional override for the daemon's per-claim processor. `None` uses
+    /// [`DefaultRequestProcessor`] inside the daemon, preserving the
+    /// existing batch path. `Some(_)` is threaded through to
+    /// [`Daemon::with_processor`] when [`run`](Self::run) starts the
+    /// background worker.
+    processor: Option<Arc<dyn crate::processor::RequestProcessor<Self, H>>>,
 }
 
 /// Macro for extracting a [`Batch`] from a dynamic query row (PgRow).
@@ -172,6 +178,7 @@ impl<P: PoolProvider> PostgresRequestManager<P, crate::http::ReqwestHttpClient> 
             config,
             download_buffer_size: 100,
             batch_insert_strategy: BatchInsertStrategy::default(),
+            processor: None,
         }
     }
 }
@@ -196,7 +203,22 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
             config: DaemonConfig::default(),
             download_buffer_size: 100,
             batch_insert_strategy: BatchInsertStrategy::default(),
+            processor: None,
         }
+    }
+
+    /// Override the daemon's per-claim processor.
+    ///
+    /// By default the manager runs the daemon with
+    /// [`DefaultRequestProcessor`], preserving the existing batch path. Use
+    /// this builder to plug in a custom [`RequestProcessor`] (e.g. dwctl's
+    /// multi-step Open Responses dispatcher).
+    pub fn with_processor(
+        mut self,
+        processor: Arc<dyn crate::processor::RequestProcessor<Self, H>>,
+    ) -> Self {
+        self.processor = Some(processor);
+        self
     }
 
     /// Set a custom daemon configuration.
@@ -5100,12 +5122,16 @@ impl<P: PoolProvider, H: HttpClient + 'static> DaemonExecutor<H> for PostgresReq
     ) -> Result<JoinHandle<Result<()>>> {
         tracing::info!("Starting PostgreSQL request manager daemon");
 
-        let daemon = Arc::new(Daemon::new(
+        let mut daemon = Daemon::new(
             self.clone(),
             self.http_client.clone(),
             self.config.clone(),
             shutdown_token,
-        ));
+        );
+        if let Some(processor) = self.processor.clone() {
+            daemon = daemon.with_processor(processor);
+        }
+        let daemon = Arc::new(daemon);
 
         let handle = tokio::spawn(async move {
             // Daemon will poll for cancelled batches periodically

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -93,7 +93,15 @@ pub struct PostgresRequestManager<P: PoolProvider, H: HttpClient> {
     /// existing batch path. `Some(_)` is threaded through to
     /// [`Daemon::with_processor`] when [`run`](Self::run) starts the
     /// background worker.
-    processor: Option<Arc<dyn crate::processor::RequestProcessor<Self, H>>>,
+    ///
+    /// Wrapped in a [`OnceLock`] to support late wiring: in production
+    /// `dwctl` constructs the manager first (so the response-store can
+    /// reference it), then constructs the processor (which needs the
+    /// response-store), then injects the processor here via
+    /// [`set_processor`](Self::set_processor) before the daemon starts.
+    /// The builder-style [`with_processor`](Self::with_processor) remains
+    /// available for tests and consumers that don't have a cycle.
+    processor: std::sync::OnceLock<Arc<dyn crate::processor::RequestProcessor<Self, H>>>,
 }
 
 /// Macro for extracting a [`Batch`] from a dynamic query row (PgRow).
@@ -178,7 +186,7 @@ impl<P: PoolProvider> PostgresRequestManager<P, crate::http::ReqwestHttpClient> 
             config,
             download_buffer_size: 100,
             batch_insert_strategy: BatchInsertStrategy::default(),
-            processor: None,
+            processor: std::sync::OnceLock::new(),
         }
     }
 }
@@ -203,7 +211,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
             config: DaemonConfig::default(),
             download_buffer_size: 100,
             batch_insert_strategy: BatchInsertStrategy::default(),
-            processor: None,
+            processor: std::sync::OnceLock::new(),
         }
     }
 
@@ -214,11 +222,31 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
     /// this builder to plug in a custom [`RequestProcessor`] (e.g. dwctl's
     /// multi-step Open Responses dispatcher).
     pub fn with_processor(
-        mut self,
+        self,
         processor: Arc<dyn crate::processor::RequestProcessor<Self, H>>,
     ) -> Self {
-        self.processor = Some(processor);
+        // Builder form: use OnceLock::set, ignore the result because by
+        // construction we're the only writer here.
+        let _ = self.processor.set(processor);
         self
+    }
+
+    /// Inject the per-claim processor after the manager has already been
+    /// Arc-wrapped. Returns `Err` if a processor is already set (callers
+    /// should set it exactly once).
+    ///
+    /// This is the late-wiring entry point: dwctl needs the manager to
+    /// exist before it can build a `FusilladeResponseStore`, which in
+    /// turn is needed to build the `DwctlRequestProcessor`. After all
+    /// three are constructed, this method attaches the processor before
+    /// `run()` starts the daemon.
+    pub fn set_processor(
+        &self,
+        processor: Arc<dyn crate::processor::RequestProcessor<Self, H>>,
+    ) -> std::result::Result<(), &'static str> {
+        self.processor
+            .set(processor)
+            .map_err(|_| "processor already set")
     }
 
     /// Set a custom daemon configuration.
@@ -5128,7 +5156,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> DaemonExecutor<H> for PostgresReq
             self.config.clone(),
             shutdown_token,
         );
-        if let Some(processor) = self.processor.clone() {
+        if let Some(processor) = self.processor.get().cloned() {
             daemon = daemon.with_processor(processor);
         }
         let daemon = Arc::new(daemon);

--- a/src/manager/response_step.rs
+++ b/src/manager/response_step.rs
@@ -1,0 +1,282 @@
+//! PostgreSQL implementation of [`ResponseStepStore`].
+//!
+//! Mirrors the structural patterns of [`PostgresRequestManager`]: a thin
+//! wrapper over a [`PoolProvider`] using runtime-checked `sqlx::query()`
+//! against the `response_steps` table.
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::error::{FusilladeError, Result};
+use crate::request::RequestId;
+use crate::response_step::{
+    CreateStepInput, ResponseStep, ResponseStepStore, StepId, StepKind, StepState,
+};
+
+pub use sqlx_pool_router::PoolProvider;
+
+/// PostgreSQL implementation of [`ResponseStepStore`].
+///
+/// Holds a [`PoolProvider`] for write/read pool selection, mirroring
+/// [`crate::PostgresRequestManager`]. Construct directly or share the
+/// same `PoolProvider` instance with a request manager so that both
+/// stores see consistent reads.
+pub struct PostgresResponseStepManager<P: PoolProvider> {
+    pools: P,
+}
+
+impl<P: PoolProvider> PostgresResponseStepManager<P> {
+    pub fn new(pools: P) -> Self {
+        Self { pools }
+    }
+}
+
+fn step_from_row(row: &sqlx::postgres::PgRow) -> Result<ResponseStep> {
+    let kind_str: String = row.get("step_kind");
+    let kind = StepKind::parse(&kind_str).ok_or_else(|| {
+        FusilladeError::Other(anyhow!("Unknown step_kind in response_steps: {}", kind_str))
+    })?;
+
+    let state_str: String = row.get("state");
+    let state = StepState::parse(&state_str).ok_or_else(|| {
+        FusilladeError::Other(anyhow!("Unknown state in response_steps: {}", state_str))
+    })?;
+
+    Ok(ResponseStep {
+        id: StepId(row.get("id")),
+        request_id: RequestId(row.get("request_id")),
+        prev_step_id: row.get::<Option<Uuid>, _>("prev_step_id").map(StepId),
+        parent_step_id: row.get::<Option<Uuid>, _>("parent_step_id").map(StepId),
+        step_kind: kind,
+        step_sequence: row.get("step_sequence"),
+        request_payload: row.get("request_payload"),
+        response_payload: row.get::<Option<serde_json::Value>, _>("response_payload"),
+        state,
+        started_at: row.get::<Option<DateTime<Utc>>, _>("started_at"),
+        completed_at: row.get::<Option<DateTime<Utc>>, _>("completed_at"),
+        failed_at: row.get::<Option<DateTime<Utc>>, _>("failed_at"),
+        canceled_at: row.get::<Option<DateTime<Utc>>, _>("canceled_at"),
+        retry_attempt: row.get("retry_attempt"),
+        error: row.get::<Option<serde_json::Value>, _>("error"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+const STEP_COLUMNS: &str = "id, request_id, prev_step_id, parent_step_id, step_kind, step_sequence, \
+    request_payload, response_payload, state, started_at, completed_at, failed_at, \
+    canceled_at, retry_attempt, error, created_at, updated_at";
+
+#[async_trait]
+impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
+    async fn create_step(&self, input: CreateStepInput) -> Result<StepId> {
+        let pool = self.pools.write();
+        let id = input.id.unwrap_or_else(Uuid::new_v4);
+
+        sqlx::query(
+            "INSERT INTO response_steps \
+             (id, request_id, prev_step_id, parent_step_id, step_kind, step_sequence, request_payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(id)
+        .bind(input.request_id.0)
+        .bind(input.prev_step_id.map(|s| s.0))
+        .bind(input.parent_step_id.map(|s| s.0))
+        .bind(input.step_kind.as_str())
+        .bind(input.step_sequence)
+        .bind(&input.request_payload)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to insert response_step: {}", e)))?;
+
+        Ok(StepId(id))
+    }
+
+    async fn get_step(&self, id: StepId) -> Result<Option<ResponseStep>> {
+        let pool = self.pools.read();
+        let query = format!("SELECT {} FROM response_steps WHERE id = $1", STEP_COLUMNS);
+        let row = sqlx::query(&query)
+            .bind(id.0)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to fetch response_step: {}", e)))?;
+
+        row.as_ref().map(step_from_row).transpose()
+    }
+
+    async fn list_chain(&self, request_id: RequestId) -> Result<Vec<ResponseStep>> {
+        let pool = self.pools.read();
+        let query = format!(
+            "SELECT {} FROM response_steps WHERE request_id = $1 ORDER BY step_sequence ASC",
+            STEP_COLUMNS
+        );
+        let rows = sqlx::query(&query)
+            .bind(request_id.0)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to list response_steps: {}", e)))?;
+
+        rows.iter().map(step_from_row).collect()
+    }
+
+    async fn list_scope(
+        &self,
+        request_id: RequestId,
+        scope_parent: Option<StepId>,
+    ) -> Result<Vec<ResponseStep>> {
+        let pool = self.pools.read();
+        // Postgres treats NULL parent_step_id as its own group; use IS NOT
+        // DISTINCT FROM so a NULL parameter matches NULL rows.
+        let query = format!(
+            "SELECT {} FROM response_steps \
+             WHERE request_id = $1 AND parent_step_id IS NOT DISTINCT FROM $2 \
+             ORDER BY step_sequence ASC",
+            STEP_COLUMNS
+        );
+        let rows = sqlx::query(&query)
+            .bind(request_id.0)
+            .bind(scope_parent.map(|s| s.0))
+            .fetch_all(pool)
+            .await
+            .map_err(|e| FusilladeError::Other(anyhow!("Failed to list response_steps: {}", e)))?;
+
+        rows.iter().map(step_from_row).collect()
+    }
+
+    async fn mark_step_processing(&self, id: StepId) -> Result<()> {
+        let pool = self.pools.write();
+        let result = sqlx::query(
+            "UPDATE response_steps \
+             SET state = 'processing', started_at = NOW(), updated_at = NOW() \
+             WHERE id = $1 AND state = 'pending'",
+        )
+        .bind(id.0)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to mark step as processing: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            // Idempotent: the row may already be processing or terminal under
+            // crash recovery; surface only if the row is genuinely missing.
+            let exists = sqlx::query("SELECT 1 FROM response_steps WHERE id = $1")
+                .bind(id.0)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| {
+                    FusilladeError::Other(anyhow!("Failed to verify step existence: {}", e))
+                })?;
+            if exists.is_none() {
+                return Err(FusilladeError::Other(anyhow!(
+                    "response_step not found: {}",
+                    id
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn complete_step(&self, id: StepId, response: serde_json::Value) -> Result<()> {
+        let pool = self.pools.write();
+        let result = sqlx::query(
+            "UPDATE response_steps \
+             SET state = 'completed', \
+                 response_payload = $2, \
+                 completed_at = NOW(), \
+                 updated_at = NOW() \
+             WHERE id = $1 AND state IN ('pending', 'processing')",
+        )
+        .bind(id.0)
+        .bind(&response)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to complete response_step: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::Other(anyhow!(
+                "response_step not in completable state: {}",
+                id
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn fail_step(&self, id: StepId, error: serde_json::Value) -> Result<()> {
+        let pool = self.pools.write();
+        let result = sqlx::query(
+            "UPDATE response_steps \
+             SET state = 'failed', \
+                 error = $2, \
+                 failed_at = NOW(), \
+                 updated_at = NOW() \
+             WHERE id = $1 AND state IN ('pending', 'processing')",
+        )
+        .bind(id.0)
+        .bind(&error)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail response_step: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::Other(anyhow!(
+                "response_step not in failable state: {}",
+                id
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn cancel_step(&self, id: StepId) -> Result<()> {
+        let pool = self.pools.write();
+        let result = sqlx::query(
+            "UPDATE response_steps \
+             SET state = 'canceled', \
+                 canceled_at = NOW(), \
+                 updated_at = NOW() \
+             WHERE id = $1 AND state IN ('pending', 'processing')",
+        )
+        .bind(id.0)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to cancel response_step: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::Other(anyhow!(
+                "response_step not in cancelable state: {}",
+                id
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn requeue_step_for_retry(&self, id: StepId) -> Result<()> {
+        let pool = self.pools.write();
+        let result = sqlx::query(
+            "UPDATE response_steps \
+             SET state = 'pending', \
+                 retry_attempt = retry_attempt + 1, \
+                 started_at = NULL, \
+                 updated_at = NOW() \
+             WHERE id = $1 AND state = 'processing'",
+        )
+        .bind(id.0)
+        .execute(pool)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to requeue response_step: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            return Err(FusilladeError::Other(anyhow!(
+                "response_step not in retryable state: {}",
+                id
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/src/manager/response_step.rs
+++ b/src/manager/response_step.rs
@@ -24,6 +24,14 @@ pub use sqlx_pool_router::PoolProvider;
 /// [`crate::PostgresRequestManager`]. Construct directly or share the
 /// same `PoolProvider` instance with a request manager so that both
 /// stores see consistent reads.
+///
+/// All read methods on this impl route through the **write/primary**
+/// pool. The orchestration loop reads its own freshly-written rows on
+/// every iteration (e.g., `list_scope` after `create_step` to confirm the
+/// frontier under crash recovery), and read-replica lag would surface as
+/// `None` or stale rows. The dashboard, if it ever queries the
+/// `response_steps` table, should grow a separate replica-routed read
+/// path rather than re-using these methods.
 pub struct PostgresResponseStepManager<P: PoolProvider> {
     pools: P,
 }
@@ -70,6 +78,18 @@ const STEP_COLUMNS: &str = "id, request_id, prev_step_id, parent_step_id, step_k
     request_payload, response_payload, state, started_at, completed_at, failed_at, \
     canceled_at, retry_attempt, error, created_at, updated_at";
 
+/// Look up the current state of a step. Used by the lifecycle update
+/// methods to disambiguate "row not found" from "row in unexpected state"
+/// after a 0-rows-affected update.
+async fn fetch_state(pool: &sqlx::PgPool, id: StepId) -> Result<Option<String>> {
+    sqlx::query("SELECT state FROM response_steps WHERE id = $1")
+        .bind(id.0)
+        .fetch_optional(pool)
+        .await
+        .map(|opt| opt.map(|row| row.get::<String, _>("state")))
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to fetch step state: {}", e)))
+}
+
 #[async_trait]
 impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
     async fn create_step(&self, input: CreateStepInput) -> Result<StepId> {
@@ -96,7 +116,8 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
     }
 
     async fn get_step(&self, id: StepId) -> Result<Option<ResponseStep>> {
-        let pool = self.pools.read();
+        // Reads go through the primary pool; see the type-level doc for why.
+        let pool = self.pools.write();
         let query = format!("SELECT {} FROM response_steps WHERE id = $1", STEP_COLUMNS);
         let row = sqlx::query(&query)
             .bind(id.0)
@@ -108,7 +129,7 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
     }
 
     async fn list_chain(&self, request_id: RequestId) -> Result<Vec<ResponseStep>> {
-        let pool = self.pools.read();
+        let pool = self.pools.write();
         let query = format!(
             "SELECT {} FROM response_steps WHERE request_id = $1 ORDER BY step_sequence ASC",
             STEP_COLUMNS
@@ -127,7 +148,7 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         request_id: RequestId,
         scope_parent: Option<StepId>,
     ) -> Result<Vec<ResponseStep>> {
-        let pool = self.pools.read();
+        let pool = self.pools.write();
         // Postgres treats NULL parent_step_id as its own group; use IS NOT
         // DISTINCT FROM so a NULL parameter matches NULL rows.
         let query = format!(
@@ -161,14 +182,7 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         if result.rows_affected() == 0 {
             // Idempotent: the row may already be processing or terminal under
             // crash recovery; surface only if the row is genuinely missing.
-            let exists = sqlx::query("SELECT 1 FROM response_steps WHERE id = $1")
-                .bind(id.0)
-                .fetch_optional(pool)
-                .await
-                .map_err(|e| {
-                    FusilladeError::Other(anyhow!("Failed to verify step existence: {}", e))
-                })?;
-            if exists.is_none() {
+            if fetch_state(pool, id).await?.is_none() {
                 return Err(FusilladeError::Other(anyhow!(
                     "response_step not found: {}",
                     id
@@ -196,10 +210,14 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to complete response_step: {}", e)))?;
 
         if result.rows_affected() == 0 {
-            return Err(FusilladeError::Other(anyhow!(
-                "response_step not in completable state: {}",
-                id
-            )));
+            return Err(match fetch_state(pool, id).await? {
+                Some(state) => FusilladeError::Other(anyhow!(
+                    "response_step {} not in completable state (current: {})",
+                    id,
+                    state
+                )),
+                None => FusilladeError::Other(anyhow!("response_step not found: {}", id)),
+            });
         }
 
         Ok(())
@@ -222,10 +240,14 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail response_step: {}", e)))?;
 
         if result.rows_affected() == 0 {
-            return Err(FusilladeError::Other(anyhow!(
-                "response_step not in failable state: {}",
-                id
-            )));
+            return Err(match fetch_state(pool, id).await? {
+                Some(state) => FusilladeError::Other(anyhow!(
+                    "response_step {} not in failable state (current: {})",
+                    id,
+                    state
+                )),
+                None => FusilladeError::Other(anyhow!("response_step not found: {}", id)),
+            });
         }
 
         Ok(())
@@ -246,10 +268,14 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to cancel response_step: {}", e)))?;
 
         if result.rows_affected() == 0 {
-            return Err(FusilladeError::Other(anyhow!(
-                "response_step not in cancelable state: {}",
-                id
-            )));
+            return Err(match fetch_state(pool, id).await? {
+                Some(state) => FusilladeError::Other(anyhow!(
+                    "response_step {} not in cancelable state (current: {})",
+                    id,
+                    state
+                )),
+                None => FusilladeError::Other(anyhow!("response_step not found: {}", id)),
+            });
         }
 
         Ok(())
@@ -271,10 +297,14 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to requeue response_step: {}", e)))?;
 
         if result.rows_affected() == 0 {
-            return Err(FusilladeError::Other(anyhow!(
-                "response_step not in retryable state: {}",
-                id
-            )));
+            return Err(match fetch_state(pool, id).await? {
+                Some(state) => FusilladeError::Other(anyhow!(
+                    "response_step {} not in retryable state (current: {})",
+                    id,
+                    state
+                )),
+                None => FusilladeError::Other(anyhow!("response_step not found: {}", id)),
+            });
         }
 
         Ok(())

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,0 +1,158 @@
+//! Per-row processing hook for the daemon.
+//!
+//! The daemon's per-claim processing pipeline today is a fixed sequence: fire
+//! the HTTP request, wait for it (or for a cancellation), persist the result.
+//! Multi-step Open Responses orchestration (see
+//! `docs/plans/2026-04-28-multi-step-responses.md`) needs to inject custom
+//! work in this slot — running an agent loop instead of a single fire — but
+//! the existing batch path must keep its current behavior byte-for-byte.
+//!
+//! The [`RequestProcessor`] trait is that hook. The daemon constructs the
+//! cross-cutting state (cancellation tokens, span context, metrics handles)
+//! and hands the inner two-phase HTTP fire (`Claimed -> Processing -> terminal`)
+//! to the processor. [`DefaultRequestProcessor`] is the no-change default that
+//! mirrors today's pipeline; downstream consumers (notably dwctl) implement
+//! the trait to dispatch on `request.data.endpoint` and run a different
+//! pipeline for `/v1/responses` while delegating everything else to the
+//! default.
+//!
+//! ## What the processor owns vs. what the daemon owns
+//!
+//! The processor owns only the inner HTTP-fire pair. The daemon retains:
+//!
+//! - per-model and per-user in-flight gauges + counters
+//! - the `tokio::select!` between batch-cancel and shutdown tokens (the
+//!   resulting `CancellationReason` future is passed in to the processor as
+//!   an opaque future)
+//! - retry orchestration after a `Failed` outcome (`can_retry`, persist
+//!   `Pending`)
+//! - daemon-level `outcome` field on the parent span
+//!
+//! This keeps cross-cutting concerns out of the trait and avoids forcing
+//! every implementor to re-replicate them.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::Instrument;
+
+use crate::error::Result;
+use crate::http::{HttpClient, HttpResponse};
+use crate::manager::Storage;
+use crate::request::{Claimed, Request, RequestCompletionResult, transitions::CancellationReason};
+
+/// Boxed future the daemon hands the processor for cooperative cancellation.
+///
+/// Constructed in the daemon by `select!`-ing the per-batch token and the
+/// daemon-wide shutdown token; resolves to the cancellation reason.
+pub type CancellationFuture = Pin<Box<dyn std::future::Future<Output = CancellationReason> + Send>>;
+
+/// Predicate the daemon hands the processor to classify upstream HTTP
+/// responses as success vs. retriable failure.
+pub type ShouldRetry = Arc<dyn Fn(&HttpResponse) -> bool + Send + Sync>;
+
+/// Per-claim processing hook.
+///
+/// The trait is generic over the storage and HTTP client types the daemon was
+/// constructed with so that the existing typestate methods (`request.process`,
+/// `processing.complete`) can be used without `dyn` indirection.
+///
+/// Implementations must drive a `Request<Claimed>` to a terminal state,
+/// returning the appropriate [`RequestCompletionResult`]. The daemon will
+/// then handle retry persistence and metric emission against that outcome.
+#[async_trait]
+pub trait RequestProcessor<S, H>: Send + Sync
+where
+    S: Storage + Sync,
+    H: HttpClient + 'static,
+{
+    /// Process a single claimed request through to a terminal state.
+    ///
+    /// Implementations should:
+    ///
+    /// - Move `request` into a `Processing` state by firing the upstream HTTP
+    ///   call (typically via `request.process(http, storage)`).
+    /// - Wait for the result (or for `cancellation` to resolve), classifying
+    ///   non-2xx responses with `should_retry` to decide whether to retry.
+    /// - Return the typed terminal request.
+    ///
+    /// The default impl ([`DefaultRequestProcessor`]) is the canonical
+    /// reference for this contract.
+    async fn process(
+        &self,
+        request: Request<Claimed>,
+        http: H,
+        storage: &S,
+        should_retry: ShouldRetry,
+        cancellation: CancellationFuture,
+    ) -> Result<RequestCompletionResult>;
+}
+
+/// Default processor that preserves today's daemon behavior exactly.
+///
+/// Wraps the existing two-phase typestate pipeline:
+///
+/// ```ignore
+/// let processing = request.process(http, storage).await?;
+/// processing.complete(storage, should_retry, cancellation).await
+/// ```
+///
+/// inside the same `fusillade.state.claimed` and `fusillade.state.processing`
+/// spans the daemon used to emit inline. Any consumer that does not provide
+/// its own processor gets this for free, so the existing batch path is
+/// unchanged.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultRequestProcessor;
+
+#[async_trait]
+impl<S, H> RequestProcessor<S, H> for DefaultRequestProcessor
+where
+    S: Storage + Sync,
+    H: HttpClient + 'static,
+{
+    async fn process(
+        &self,
+        request: Request<Claimed>,
+        http: H,
+        storage: &S,
+        should_retry: ShouldRetry,
+        cancellation: CancellationFuture,
+    ) -> Result<RequestCompletionResult> {
+        let request_id = request.data.id;
+        let daemon_id = request.state.daemon_id;
+        let retry_attempt = request.state.retry_attempt;
+
+        // Span 1: claimed -> processing (HTTP request kicked off)
+        let processing = async {
+            tracing::debug!("Sending batch request to inference endpoint");
+            request.process(http, storage).await
+        }
+        .instrument(tracing::info_span!(
+            "fusillade.state.claimed",
+            otel.name = "fusillade.state.claimed",
+            request_id = %request_id,
+            daemon_id = %daemon_id,
+            retry_attempt,
+        ))
+        .await?;
+
+        // Capture for the second span — Completed state drops these fields.
+        let retry_attempt_at_completion = processing.state.retry_attempt;
+
+        // Span 2: processing -> terminal (HTTP in-flight, awaiting result or
+        // cancellation)
+        async {
+            processing
+                .complete(storage, |response| (should_retry)(response), cancellation)
+                .await
+        }
+        .instrument(tracing::info_span!(
+            "fusillade.state.processing",
+            otel.name = "fusillade.state.processing",
+            request_id = %request_id,
+            retry_attempt = retry_attempt_at_completion,
+        ))
+        .await
+    }
+}

--- a/src/response_step.rs
+++ b/src/response_step.rs
@@ -1,0 +1,216 @@
+//! Response step storage primitives for multi-step Open Responses orchestration.
+//!
+//! A response step is a discrete unit of work inside a multi-step response: a
+//! single upstream model call or tool call. Steps are linked into a linear chain
+//! via `prev_step_id` and may be nested under a `parent_step_id` to express
+//! sub-agent recursion. The orchestration loop (in `onwards`) decides what the
+//! next step is given the chain so far; the storage layer here is purely
+//! infrastructure — no Open Responses domain knowledge.
+//!
+//! See `docs/plans/2026-04-28-multi-step-responses.md`.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::request::RequestId;
+
+/// Identifier of a single response step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StepId(pub Uuid);
+
+impl std::fmt::Display for StepId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0.to_string()[..8])
+    }
+}
+
+impl From<Uuid> for StepId {
+    fn from(uuid: Uuid) -> Self {
+        StepId(uuid)
+    }
+}
+
+impl std::ops::Deref for StepId {
+    type Target = Uuid;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Discrete kinds of work a response step can represent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepKind {
+    /// Upstream LLM invocation.
+    ModelCall,
+    /// Server-side tool invocation (HTTP tool or sub-agent dispatch).
+    ToolCall,
+}
+
+impl StepKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepKind::ModelCall => "model_call",
+            StepKind::ToolCall => "tool_call",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "model_call" => Some(StepKind::ModelCall),
+            "tool_call" => Some(StepKind::ToolCall),
+            _ => None,
+        }
+    }
+}
+
+/// Lifecycle state of a step. Mirrors `requests.state` values exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepState {
+    Pending,
+    Processing,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+impl StepState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepState::Pending => "pending",
+            StepState::Processing => "processing",
+            StepState::Completed => "completed",
+            StepState::Failed => "failed",
+            StepState::Canceled => "canceled",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(StepState::Pending),
+            "processing" => Some(StepState::Processing),
+            "completed" => Some(StepState::Completed),
+            "failed" => Some(StepState::Failed),
+            "canceled" => Some(StepState::Canceled),
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            StepState::Completed | StepState::Failed | StepState::Canceled
+        )
+    }
+}
+
+/// A row from the `response_steps` table.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResponseStep {
+    pub id: StepId,
+    pub request_id: RequestId,
+    pub prev_step_id: Option<StepId>,
+    pub parent_step_id: Option<StepId>,
+    pub step_kind: StepKind,
+    pub step_sequence: i64,
+    pub request_payload: serde_json::Value,
+    pub response_payload: Option<serde_json::Value>,
+    pub state: StepState,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub failed_at: Option<DateTime<Utc>>,
+    pub canceled_at: Option<DateTime<Utc>>,
+    pub retry_attempt: i32,
+    pub error: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input to [`ResponseStepStore::create_step`].
+///
+/// `step_sequence` is monotonic per `request_id` across all nesting levels and
+/// doubles as the `Last-Event-ID` cursor for top-level events. Callers
+/// (the orchestration loop) are responsible for picking the next sequence
+/// value — the storage layer does not enforce monotonicity beyond what the
+/// `UNIQUE (request_id, parent_step_id, prev_step_id, step_kind)` constraint
+/// implicitly provides.
+#[derive(Debug, Clone)]
+pub struct CreateStepInput {
+    /// Optional pre-generated step UUID. When `Some`, becomes the step's
+    /// primary key — useful when the caller needs to reference the id
+    /// before the row is committed (e.g., emitting an SSE event with the
+    /// step id while the row is still being inserted).
+    pub id: Option<Uuid>,
+    pub request_id: RequestId,
+    pub prev_step_id: Option<StepId>,
+    pub parent_step_id: Option<StepId>,
+    pub step_kind: StepKind,
+    pub step_sequence: i64,
+    pub request_payload: serde_json::Value,
+}
+
+/// Storage trait for response step persistence.
+///
+/// Mirrors the shape of [`crate::Storage`] for requests but scoped to the
+/// `response_steps` table. Implementations must be safe to call from multiple
+/// concurrent tasks within a single worker (tool fan-out within a single
+/// response holds the parent request lease, so no cross-worker coordination
+/// is required).
+#[async_trait]
+pub trait ResponseStepStore: Send + Sync {
+    /// Insert a new step in `pending` state.
+    ///
+    /// The `UNIQUE (request_id, parent_step_id, prev_step_id, step_kind)`
+    /// constraint is the idempotency safety net: a re-running transition
+    /// function under crash recovery will not produce duplicate successor
+    /// rows. Implementations should surface that as a typed conflict so
+    /// callers can fall back to reading the existing row.
+    async fn create_step(&self, input: CreateStepInput) -> Result<StepId>;
+
+    /// Fetch a single step by id. Returns `None` if not present.
+    async fn get_step(&self, id: StepId) -> Result<Option<ResponseStep>>;
+
+    /// List every step for a request, ordered by `step_sequence`.
+    ///
+    /// Includes both top-level and nested (sub-agent) steps. Callers that
+    /// only want the user-visible chain should filter on
+    /// `parent_step_id IS NULL`.
+    async fn list_chain(&self, request_id: RequestId) -> Result<Vec<ResponseStep>>;
+
+    /// List steps inside a specific scope ordered by `step_sequence`.
+    ///
+    /// `scope_parent` selects the chain: `None` = the top-level chain
+    /// (user-visible response), `Some(step_id)` = the sub-loop spawned by
+    /// that tool_call step.
+    async fn list_scope(
+        &self,
+        request_id: RequestId,
+        scope_parent: Option<StepId>,
+    ) -> Result<Vec<ResponseStep>>;
+
+    /// Mark a `pending` step as `processing`, recording `started_at`.
+    ///
+    /// Idempotent: if the step is already in a non-pending state the call
+    /// returns `Ok(())` without modifying the row, so crash recovery can
+    /// resume safely.
+    async fn mark_step_processing(&self, id: StepId) -> Result<()>;
+
+    /// Mark a step as `completed` with the given `response_payload`.
+    async fn complete_step(&self, id: StepId, response: serde_json::Value) -> Result<()>;
+
+    /// Mark a step as `failed` with the given structured error payload.
+    async fn fail_step(&self, id: StepId, error: serde_json::Value) -> Result<()>;
+
+    /// Mark a step as `canceled`.
+    async fn cancel_step(&self, id: StepId) -> Result<()>;
+
+    /// Increment a step's `retry_attempt` and reset it to `pending` for re-
+    /// firing under crash recovery. Used when a worker picks up a step
+    /// that was left in `processing` by a dead worker.
+    async fn requeue_step_for_retry(&self, id: StepId) -> Result<()>;
+}

--- a/src/response_step.rs
+++ b/src/response_step.rs
@@ -68,7 +68,11 @@ impl StepKind {
     }
 }
 
-/// Lifecycle state of a step. Mirrors `requests.state` values exactly.
+/// Lifecycle state of a step.
+///
+/// Mirrors a subset of the `requests.state` lifecycle. `claimed` is omitted
+/// because steps do not carry their own lease — serialized access is provided
+/// by the parent request's lease, held by the worker driving the chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StepState {
@@ -168,8 +172,11 @@ pub trait ResponseStepStore: Send + Sync {
     /// The `UNIQUE (request_id, parent_step_id, prev_step_id, step_kind)`
     /// constraint is the idempotency safety net: a re-running transition
     /// function under crash recovery will not produce duplicate successor
-    /// rows. Implementations should surface that as a typed conflict so
-    /// callers can fall back to reading the existing row.
+    /// rows. The conflict is reported through the store's normal error
+    /// path; callers that need idempotent recovery should detect the
+    /// duplicate via [`ResponseStepStore::list_scope`] (which is the
+    /// authoritative way to find the existing frontier under recovery)
+    /// rather than relying on parsing this error.
     async fn create_step(&self, input: CreateStepInput) -> Result<StepId>;
 
     /// Fetch a single step by id. Returns `None` if not present.

--- a/tests/request_processor.rs
+++ b/tests/request_processor.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the [`RequestProcessor`] daemon hook.
+//!
+//! Covers:
+//! - The default processor preserves today's batch path (a request claimed by
+//!   the daemon completes via the same mock HTTP fixture that drove the
+//!   pre-hook integration tests).
+//! - A custom processor is invoked exactly once per claimed request, with
+//!   the daemon's storage/http/cancellation parameters threaded through.
+//!
+//! These tests guard against accidental regressions in the spawn-task wiring.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fusillade::TestDbPools;
+use fusillade::batch::{BatchInput, RequestTemplateInput};
+use fusillade::daemon::{DaemonConfig, default_should_retry};
+use fusillade::http::{HttpClient, HttpResponse, MockHttpClient};
+use fusillade::manager::postgres::PostgresRequestManager;
+use fusillade::manager::{DaemonExecutor, Storage};
+use fusillade::processor::{
+    CancellationFuture, DefaultRequestProcessor, RequestProcessor, ShouldRetry,
+};
+use fusillade::request::{Claimed, Completed, Failed, Request, RequestCompletionResult};
+use tokio_util::sync::CancellationToken;
+
+fn fast_test_config() -> DaemonConfig {
+    let model_concurrency_limits = Arc::new(dashmap::DashMap::new());
+    model_concurrency_limits.insert("test-model".to_string(), 10);
+    DaemonConfig {
+        claim_batch_size: 10,
+        claim_interval_ms: 10,
+        model_concurrency_limits,
+        max_retries: Some(3),
+        backoff_ms: 100,
+        backoff_factor: 2,
+        max_backoff_ms: 1000,
+        status_log_interval_ms: None,
+        heartbeat_interval_ms: 10000,
+        should_retry: Arc::new(default_should_retry),
+        claim_timeout_ms: 60000,
+        processing_timeout_ms: 600000,
+        cancellation_poll_interval_ms: 100,
+        ..Default::default()
+    }
+}
+
+async fn submit_one_request(
+    manager: &Arc<PostgresRequestManager<TestDbPools, MockHttpClient>>,
+) -> fusillade::request::RequestId {
+    let template = RequestTemplateInput {
+        custom_id: None,
+        endpoint: "http://upstream".into(),
+        method: "POST".into(),
+        path: "/v1/test".into(),
+        body: r#"{"hello":"world"}"#.into(),
+        model: "test-model".into(),
+        api_key: "test-key".into(),
+    };
+    let file_id = manager
+        .create_file("test_file".into(), None, vec![template])
+        .await
+        .unwrap();
+    let batch = manager
+        .create_batch(BatchInput {
+            file_id,
+            endpoint: "/v1/test".into(),
+            completion_window: "24h".into(),
+            metadata: None,
+            created_by: Some("tester".into()),
+            api_key_id: None,
+            api_key: None,
+            total_requests: None,
+        })
+        .await
+        .unwrap();
+    let requests = manager.get_batch_requests(batch.id).await.unwrap();
+    requests[0].id()
+}
+
+async fn wait_until_completed(
+    manager: &Arc<PostgresRequestManager<TestDbPools, MockHttpClient>>,
+    request_id: fusillade::request::RequestId,
+) {
+    let start = std::time::Instant::now();
+    loop {
+        let detail = manager.get_request_detail(request_id).await.unwrap();
+        if detail.status == "completed" || detail.status == "failed" {
+            return;
+        }
+        if start.elapsed() > Duration::from_secs(5) {
+            panic!(
+                "Timeout waiting for request to reach terminal state, last={:?}",
+                detail.status
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn default_processor_preserves_batch_path(pool: sqlx::PgPool) {
+    let http_client = Arc::new(MockHttpClient::new());
+    http_client.add_response(
+        "POST /v1/test",
+        Ok(HttpResponse {
+            status: 200,
+            body: r#"{"ok":true}"#.into(),
+        }),
+    );
+
+    let shutdown_token = CancellationToken::new();
+    let manager = Arc::new(
+        PostgresRequestManager::with_client(
+            TestDbPools::new(pool).await.unwrap(),
+            http_client.clone(),
+        )
+        .with_config(fast_test_config()),
+    );
+    let _handle = manager.clone().run(shutdown_token.clone()).unwrap();
+
+    let request_id = submit_one_request(&manager).await;
+    wait_until_completed(&manager, request_id).await;
+
+    let detail = manager.get_request_detail(request_id).await.unwrap();
+    assert_eq!(detail.status, "completed");
+    let body = detail.response_body.unwrap_or_default();
+    assert!(body.contains("\"ok\":true"));
+
+    shutdown_token.cancel();
+}
+
+/// Counting processor: wraps DefaultRequestProcessor and records how many
+/// times it was invoked. Validates that the daemon's spawn task actually
+/// dispatches through the trait object.
+struct CountingProcessor {
+    invocations: Arc<AtomicUsize>,
+    inner: DefaultRequestProcessor,
+}
+
+#[async_trait]
+impl<S, H> RequestProcessor<S, H> for CountingProcessor
+where
+    S: Storage + Sync,
+    H: HttpClient + 'static,
+{
+    async fn process(
+        &self,
+        request: Request<Claimed>,
+        http: H,
+        storage: &S,
+        should_retry: ShouldRetry,
+        cancellation: CancellationFuture,
+    ) -> fusillade::Result<RequestCompletionResult> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        self.inner
+            .process(request, http, storage, should_retry, cancellation)
+            .await
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn custom_processor_is_invoked(pool: sqlx::PgPool) {
+    let http_client = Arc::new(MockHttpClient::new());
+    http_client.add_response(
+        "POST /v1/test",
+        Ok(HttpResponse {
+            status: 200,
+            body: "{}".into(),
+        }),
+    );
+
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let processor = Arc::new(CountingProcessor {
+        invocations: invocations.clone(),
+        inner: DefaultRequestProcessor,
+    });
+
+    let shutdown_token = CancellationToken::new();
+    let manager = Arc::new(
+        PostgresRequestManager::with_client(
+            TestDbPools::new(pool).await.unwrap(),
+            http_client.clone(),
+        )
+        .with_config(fast_test_config())
+        .with_processor(processor),
+    );
+    let _handle = manager.clone().run(shutdown_token.clone()).unwrap();
+
+    let request_id = submit_one_request(&manager).await;
+    wait_until_completed(&manager, request_id).await;
+
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        1,
+        "processor must be invoked exactly once for a single claimed request"
+    );
+    let detail = manager.get_request_detail(request_id).await.unwrap();
+    assert_eq!(detail.status, "completed");
+
+    shutdown_token.cancel();
+}
+
+/// Synthesizes a hard failure: validates that the processor's terminal-state
+/// outcome is honored by the daemon's downstream metric/retry logic.
+struct AlwaysFailProcessor;
+
+#[async_trait]
+impl<S, H> RequestProcessor<S, H> for AlwaysFailProcessor
+where
+    S: Storage + Sync,
+    H: HttpClient + 'static,
+{
+    async fn process(
+        &self,
+        request: Request<Claimed>,
+        _http: H,
+        storage: &S,
+        _should_retry: ShouldRetry,
+        _cancellation: CancellationFuture,
+    ) -> fusillade::Result<RequestCompletionResult> {
+        // Synthesize a non-retriable failure so the daemon persists the
+        // terminal state and we can observe it via the manager.
+        let model = request.data.model.clone();
+        let retry_attempt = request.state.retry_attempt;
+        let batch_expires_at = request.state.batch_expires_at;
+        let failed = Request {
+            data: request.data,
+            state: Failed {
+                reason: fusillade::request::FailureReason::NonRetriableHttpStatus {
+                    status: 400,
+                    body: "synthetic test failure".into(),
+                },
+                failed_at: chrono::Utc::now(),
+                retry_attempt,
+                batch_expires_at,
+                routed_model: model,
+            },
+        };
+        storage.persist(&failed).await?;
+        Ok(RequestCompletionResult::Failed(failed))
+    }
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn custom_processor_can_synthesize_terminal_failure(pool: sqlx::PgPool) {
+    // No HTTP fixture needed — the processor never calls upstream.
+    let http_client = Arc::new(MockHttpClient::new());
+
+    let shutdown_token = CancellationToken::new();
+    let manager = Arc::new(
+        PostgresRequestManager::with_client(
+            TestDbPools::new(pool).await.unwrap(),
+            http_client.clone(),
+        )
+        .with_config(fast_test_config())
+        .with_processor(Arc::new(AlwaysFailProcessor)),
+    );
+    let _handle = manager.clone().run(shutdown_token.clone()).unwrap();
+
+    let request_id = submit_one_request(&manager).await;
+    wait_until_completed(&manager, request_id).await;
+
+    let detail = manager.get_request_detail(request_id).await.unwrap();
+    assert_eq!(detail.status, "failed");
+    let err = detail.error.unwrap_or_default();
+    assert!(
+        err.contains("synthetic test failure"),
+        "expected synthesized failure body in error: {err}"
+    );
+
+    shutdown_token.cancel();
+}
+
+// Compile-time check: the typestate Completed variant of RequestCompletionResult
+// is reachable from our trait, ensuring downstream consumers can construct any
+// terminal state if they need to.
+#[allow(dead_code)]
+fn _smoke_check_completed_variant(c: Request<Completed>) -> RequestCompletionResult {
+    RequestCompletionResult::Completed(c)
+}

--- a/tests/response_steps.rs
+++ b/tests/response_steps.rs
@@ -263,6 +263,63 @@ async fn fail_step_records_error_payload(pool: sqlx::PgPool) {
 }
 
 #[sqlx::test]
+async fn cancel_step_records_canceled_at_and_blocks_terminal_transitions(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    // Cancel directly from `pending` (the most common path: a request is
+    // canceled before its first step has been claimed by a worker).
+    let pending_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    store.cancel_step(pending_id).await.unwrap();
+    let s = store.get_step(pending_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Canceled);
+    assert!(s.canceled_at.is_some());
+    assert!(s.started_at.is_none());
+
+    // Subsequent terminal transitions are rejected (canceled is terminal).
+    let err = store.complete_step(pending_id, json!({"x": 1})).await;
+    assert!(err.is_err(), "complete_step on canceled step must fail");
+    let err = store.fail_step(pending_id, json!({"x": 1})).await;
+    assert!(err.is_err(), "fail_step on canceled step must fail");
+    let err = store.cancel_step(pending_id).await;
+    assert!(err.is_err(), "second cancel_step must fail");
+
+    // Cancel after `processing` works too — this is the path taken when a
+    // batch is canceled while a worker is mid-flight.
+    let processing_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(pending_id),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+    store.mark_step_processing(processing_id).await.unwrap();
+    store.cancel_step(processing_id).await.unwrap();
+    let s = store.get_step(processing_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Canceled);
+    assert!(s.started_at.is_some());
+    assert!(s.canceled_at.is_some());
+}
+
+#[sqlx::test]
 async fn requeue_for_retry_increments_attempt(pool: sqlx::PgPool) {
     let request_id = insert_parent_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();

--- a/tests/response_steps.rs
+++ b/tests/response_steps.rs
@@ -1,0 +1,428 @@
+//! Integration tests for the response_steps storage layer.
+//!
+//! Each test gets a fresh sqlx pool via `#[sqlx::test]`, which automatically
+//! runs every migration in `migrations/`. We insert a parent request row by
+//! hand (avoiding the full file/template/batch chain) since these tests are
+//! scoped to the response_step module only.
+
+use fusillade::request::RequestId;
+use fusillade::response_step::{CreateStepInput, ResponseStepStore, StepKind, StepState};
+use fusillade::{PostgresResponseStepManager, TestDbPools};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Insert a minimal parent `requests` row so `response_steps.request_id`'s
+/// foreign key is satisfied. Returns the new request id.
+async fn insert_parent_request(pool: &sqlx::PgPool) -> RequestId {
+    let template_id = Uuid::new_v4();
+    let request_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO request_templates \
+         (id, file_id, custom_id, endpoint, method, path, body, model, api_key, body_byte_size) \
+         VALUES ($1, NULL, NULL, $2, 'POST', '/v1/responses', '{}', 'test-model', '', 0)",
+    )
+    .bind(template_id)
+    .bind("http://upstream")
+    .execute(pool)
+    .await
+    .expect("insert template");
+
+    sqlx::query(
+        "INSERT INTO requests \
+         (id, batch_id, template_id, model, custom_id, state) \
+         VALUES ($1, NULL, $2, 'test-model', NULL, 'pending')",
+    )
+    .bind(request_id)
+    .bind(template_id)
+    .execute(pool)
+    .await
+    .expect("insert request");
+
+    RequestId(request_id)
+}
+
+#[sqlx::test]
+async fn create_and_fetch_top_level_step(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"prompt": "hello"}),
+        })
+        .await
+        .expect("create_step");
+
+    let fetched = store
+        .get_step(step_id)
+        .await
+        .expect("get_step")
+        .expect("step exists");
+
+    assert_eq!(fetched.id, step_id);
+    assert_eq!(fetched.request_id, request_id);
+    assert_eq!(fetched.step_kind, StepKind::ModelCall);
+    assert_eq!(fetched.state, StepState::Pending);
+    assert_eq!(fetched.step_sequence, 1);
+    assert_eq!(fetched.retry_attempt, 0);
+    assert!(fetched.response_payload.is_none());
+    assert!(fetched.started_at.is_none());
+    assert_eq!(fetched.request_payload, json!({"prompt": "hello"}));
+}
+
+#[sqlx::test]
+async fn list_chain_returns_steps_in_sequence_order(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    // Insert in reverse to confirm ordering is by step_sequence, not insert time
+    let step_3 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 3,
+            request_payload: json!({"step": 3}),
+        })
+        .await
+        .unwrap();
+
+    let step_1 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 1,
+            request_payload: json!({"step": 1}),
+        })
+        .await
+        .unwrap();
+
+    let step_2 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(step_1),
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 2,
+            request_payload: json!({"step": 2}),
+        })
+        .await
+        .unwrap();
+
+    let chain = store.list_chain(request_id).await.unwrap();
+    assert_eq!(chain.len(), 3);
+    assert_eq!(chain[0].id, step_1);
+    assert_eq!(chain[1].id, step_2);
+    assert_eq!(chain[2].id, step_3);
+    assert_eq!(chain[1].prev_step_id, Some(step_1));
+}
+
+#[sqlx::test]
+async fn list_scope_separates_top_level_from_sub_loop(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    // Top-level: a model_call followed by a tool_call (which spawns a sub-agent)
+    let top_1 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"top": 1}),
+        })
+        .await
+        .unwrap();
+    let top_2 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(top_1),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({"top": 2, "tool": "delegate"}),
+        })
+        .await
+        .unwrap();
+
+    // Sub-loop under top_2: a model_call.
+    let sub_1 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: Some(top_2),
+            step_kind: StepKind::ModelCall,
+            step_sequence: 3,
+            request_payload: json!({"sub": 1}),
+        })
+        .await
+        .unwrap();
+
+    let top = store.list_scope(request_id, None).await.unwrap();
+    assert_eq!(top.len(), 2);
+    assert_eq!(top[0].id, top_1);
+    assert_eq!(top[1].id, top_2);
+
+    let sub = store.list_scope(request_id, Some(top_2)).await.unwrap();
+    assert_eq!(sub.len(), 1);
+    assert_eq!(sub[0].id, sub_1);
+
+    let other_scope = store.list_scope(request_id, Some(top_1)).await.unwrap();
+    assert!(other_scope.is_empty());
+}
+
+#[sqlx::test]
+async fn lifecycle_transitions(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"p": 1}),
+        })
+        .await
+        .unwrap();
+
+    store.mark_step_processing(step_id).await.unwrap();
+    let s = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Processing);
+    assert!(s.started_at.is_some());
+
+    // mark_step_processing is idempotent — no error when already processing
+    store.mark_step_processing(step_id).await.unwrap();
+
+    store
+        .complete_step(step_id, json!({"output": "ok"}))
+        .await
+        .unwrap();
+    let s = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Completed);
+    assert_eq!(s.response_payload, Some(json!({"output": "ok"})));
+    assert!(s.completed_at.is_some());
+
+    // Cannot complete an already-terminal step.
+    let err = store.complete_step(step_id, json!({})).await;
+    assert!(err.is_err());
+}
+
+#[sqlx::test]
+async fn fail_step_records_error_payload(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 1,
+            request_payload: json!({"tool": "search"}),
+        })
+        .await
+        .unwrap();
+
+    store.mark_step_processing(step_id).await.unwrap();
+
+    let err_payload = json!({"type": "max_iterations_exceeded", "details": "stuck"});
+    store.fail_step(step_id, err_payload.clone()).await.unwrap();
+
+    let s = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Failed);
+    assert_eq!(s.error, Some(err_payload));
+    assert!(s.failed_at.is_some());
+}
+
+#[sqlx::test]
+async fn requeue_for_retry_increments_attempt(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    store.mark_step_processing(step_id).await.unwrap();
+    store.requeue_step_for_retry(step_id).await.unwrap();
+
+    let s = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(s.state, StepState::Pending);
+    assert_eq!(s.retry_attempt, 1);
+    assert!(s.started_at.is_none());
+
+    // Still pending — cannot requeue without going processing first.
+    let err = store.requeue_step_for_retry(step_id).await;
+    assert!(err.is_err());
+}
+
+#[sqlx::test]
+async fn unique_constraint_blocks_duplicate_successors(pool: sqlx::PgPool) {
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let parent = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    // First successor: prev=parent, scope=top-level, kind=tool_call
+    store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(parent),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({"first": true}),
+        })
+        .await
+        .unwrap();
+
+    // Re-running the transition function under crash recovery must not
+    // produce a duplicate row with the same (request, parent, prev, kind)
+    // tuple.
+    let dup = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(parent),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 3,
+            request_payload: json!({"first": false}),
+        })
+        .await;
+    assert!(
+        dup.is_err(),
+        "expected UNIQUE constraint violation on duplicate successor"
+    );
+
+    // Different step_kind under the same predecessor is fine.
+    store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(parent),
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 4,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+}
+
+#[sqlx::test]
+async fn parallel_tool_calls_share_prev_but_unique_kinds(pool: sqlx::PgPool) {
+    // The orchestration loop fans out N tool_call rows after a model_call
+    // emits N tool calls. The UNIQUE constraint says
+    // (request_id, parent_step_id, prev_step_id, step_kind) must be
+    // unique, so multiple parallel tool_calls under the same predecessor
+    // are NOT allowed by this constraint alone — the storage layer relies
+    // on each parallel tool_call having a distinct prev_step_id chain
+    // (the fan-out linearizes them via prev_step_id pointing at the
+    // previous sibling, not all at the same parent).
+    //
+    // This test documents that intent: parallel siblings form a linear
+    // chain by prev_step_id, even though the orchestration loop fires
+    // their HTTP calls concurrently.
+
+    let request_id = insert_parent_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let model = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    let tool_a = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(model),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({"tool": "a"}),
+        })
+        .await
+        .unwrap();
+
+    let tool_b = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id,
+            prev_step_id: Some(tool_a),
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 3,
+            request_payload: json!({"tool": "b"}),
+        })
+        .await
+        .unwrap();
+
+    let chain = store.list_chain(request_id).await.unwrap();
+    assert_eq!(chain.len(), 3);
+    assert_eq!(chain[0].id, model);
+    assert_eq!(chain[1].id, tool_a);
+    assert_eq!(chain[2].id, tool_b);
+    assert_eq!(chain[2].prev_step_id, Some(tool_a));
+}


### PR DESCRIPTION
## Summary

Foundation for multi-step Open Responses orchestration described in [docs/plans/2026-04-28-multi-step-responses.md](docs/plans/2026-04-28-multi-step-responses.md). Pure infrastructure — no Open Responses domain logic leaks into fusillade.

- New \`response_steps\` table with linear-chain (\`prev_step_id\`) and nested-scope (\`parent_step_id\`) self-references, idempotency \`UNIQUE NULLS NOT DISTINCT (request_id, parent_step_id, prev_step_id, step_kind)\` constraint, and three indexes (chain walk, predecessor lookup, sub-loop traversal).
- \`ResponseStepStore\` trait + \`StepId\` / \`StepKind\` / \`StepState\` / \`ResponseStep\` / \`CreateStepInput\` types.
- \`PostgresResponseStepManager\` implementing all 8 trait methods using \`sqlx::query()\` against the live DB (mirrors the \`PostgresRequestManager\` shape).
- \`RequestProcessor\` hook trait + \`DefaultRequestProcessor\` default impl. The trait abstracts the per-claim HTTP-fire pair; \`DefaultRequestProcessor\` wraps today's \`request.process(...).complete(...)\` pipeline byte-for-byte inside the same \`fusillade.state.claimed\` and \`fusillade.state.processing\` spans the daemon used to emit inline. The daemon spawn task replaces its inline two-phase block with a single \`processor.process(...)\` call; cancellation token plumbing, metrics gauges/counters, retry persistence, span outcomes, and SLA-missed bookkeeping all stay in the daemon.
- New \`Daemon::with_processor\` builder and \`PostgresRequestManager::with_processor\` builder. Existing \`Daemon::new\` / \`PostgresRequestManager::new\` consumers compile and behave identically — no breaking changes.
- 8 integration tests in \`tests/response_steps.rs\` and 3 in \`tests/request_processor.rs\` covering the storage layer plus the default-vs-custom processor wiring.

## Linear coverage

- Parent: [COR-328](https://linear.app/doubleword/issue/COR-328)
- Closes [COR-332](https://linear.app/doubleword/issue/COR-332) — migration
- Closes [COR-333](https://linear.app/doubleword/issue/COR-333) — trait + types
- Closes [COR-334](https://linear.app/doubleword/issue/COR-334) — Postgres impl
- Closes [COR-335](https://linear.app/doubleword/issue/COR-335) — \`RequestProcessor\` hook + daemon integration
- Closes [COR-336](https://linear.app/doubleword/issue/COR-336) — integration tests

## Why \`UNIQUE NULLS NOT DISTINCT\`

Both \`parent_step_id\` (NULL = top-level) and \`prev_step_id\` (NULL = first in scope) are nullable. Default Postgres \`UNIQUE\` treats NULLs as distinct — so the original constraint as written would not catch a duplicate top-level first step under crash recovery. PG15+ syntax fixes this; the test \`unique_constraint_blocks_duplicate_successors\` covers it.

## Why the \`RequestProcessor\` boundary is where it is

The daemon retains ownership of cross-cutting concerns (per-model and per-user in-flight gauges, the \`tokio::select!\` between batch-cancel and shutdown tokens, retry persistence after a \`Failed\` outcome, the parent process span's \`outcome\` field). The trait abstracts only the inner two-phase HTTP fire. This keeps the trait surface small and avoids forcing every implementor (notably dwctl) to re-replicate metric/cancellation/retry plumbing.

## Test plan

- [x] \`cargo test --test response_steps\` — 8 tests pass
- [x] \`cargo test --test request_processor\` — 3 tests pass (default-processor preserves the batch path; custom processor is invoked exactly once; custom processor can synthesize a terminal Failed outcome that flows through the daemon's failure-handling path)
- [x] \`cargo test --lib\` — all 129 existing tests still pass
- [x] \`cargo test --tests\` — all 18 existing daemon integration tests still pass
- [x] \`cargo clippy --lib --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Migration applies cleanly against Postgres 16
- [x] Migration revert + re-apply works

🤖 Generated with [Claude Code](https://claude.com/claude-code)