### PR TITLE
feat: re-anchor response_steps.request_id to per-step sub-request

### DIFF
--- a/docs/plans/2026-04-30-response-steps-request-linkage.md
+++ b/docs/plans/2026-04-30-response-steps-request-linkage.md
@@ -1,0 +1,313 @@
+# Response Steps ↔ Requests Linkage
+
+**Date:** 2026-04-30
+**Status:** Proposed
+**Supersedes (in part):** [2026-04-28-multi-step-responses.md](2026-04-28-multi-step-responses.md) §C7 ("Step storage" — chain identification, request_id semantic).
+
+## Summary
+
+Re-anchor `response_steps.request_id` so it points at the **sub-request
+fusillade row created for that step's HTTP fire** instead of the
+parent `/v1/responses` request, restoring the 1:1 contract between
+`requests` and `http_analytics` and unblocking per-step granular
+analytics. `parent_step_id` becomes the chain identifier (semantically
+"root_step_id"): NULL on the head step, set to the head's id on every
+non-head step. The parent `/v1/responses` request row goes away; the
+response is purely the chain.
+
+## Motivation
+
+The original multi-step plan ([§C7](2026-04-28-multi-step-responses.md))
+chose `response_steps.request_id` as the chain identifier — every step
+of one user-visible response shared the same `request_id` (= the
+parent `/v1/responses` fusillade row). This was simple to query and
+matched the daemon path's "claim the parent, walk the chain" pattern.
+
+In practice it broke two operational properties:
+
+1. **Analytics fan-out.** When the multi-step loop fires a model_call
+   via the loopback `/v1/chat/completions`, dwctl's responses
+   middleware creates a *new* fusillade `requests` row for that proxied
+   call (so onwards' outlet captures usage and writes one
+   `http_analytics` row per upstream HTTP). Those sub-request rows
+   have their own UUIDs; `response_steps` knows nothing about them.
+   The result: a parent `/v1/responses` row has **N** `http_analytics`
+   rows that nominally belong to it — but to find them you'd have to
+   either join through a non-existent column or aggregate by some
+   external grouping (which dwctl's dashboard doesn't do today).
+   Token counts, costs, and latency for parent rows show as zero.
+
+2. **No granular per-step analytics.** Even if we could find the
+   `http_analytics` rows, attributing them back to a specific step
+   requires another lookup. The natural place for that link is on
+   `response_steps` itself.
+
+The dashboard responses view also needed a way to *exclude* sub-request
+fusillade rows from the listing, since they are internal artifacts of
+the multi-step orchestration and not what the user submitted.
+
+## Design
+
+### Semantic shift
+
+| | Before | After |
+|---|---|---|
+| `request_id` | Parent `/v1/responses` row (chain identifier) | Sub-request row for *this* step's HTTP fire |
+| `prev_step_id` | Linear predecessor within scope | Tree edge — multiple steps may share a prev_step_id |
+| `parent_step_id` | Sub-agent nesting (NULL = top-level user-visible step) | Head step of the chain (NULL only on the head itself) |
+| Chain identifier | `request_id` | `parent_step_id` (= head's id) + the head's primary key for itself |
+| Parent `/v1/responses` row | Existed (anchor for `resp_<id>`, `GET /v1/responses/{id}`) | Removed; response is purely the chain |
+| `request_id` cardinality | One row per N steps in chain | One row per step (model_call); NULL for tool_call |
+
+`request_id` becomes nullable because **tool_call steps don't have a
+fusillade `requests` row** — their dispatch goes through dwctl's
+`HttpToolExecutor` directly, and their analytics live in
+`tool_call_analytics`. Only `model_call` steps fire a fusillade-tracked
+HTTP request and therefore have an associated `requests` row.
+
+### `resp_<id>` identity
+
+`resp_<id>` is the head step's `id`. `GET /v1/responses/{id}`:
+
+1. Looks up the head step by `id`.
+2. Walks descendants via the `response_steps_chain_walk` index
+   (`parent_step_id = head_id ORDER BY step_sequence`) to assemble
+   the response tree.
+
+Single-step requests (`/v1/chat/completions`, `/v1/embeddings`, etc.)
+have no associated `response_steps` rows; they're untouched by this
+plan.
+
+### Sub-agent recursion (nesting via prev_step_id)
+
+The original `parent_step_id` semantic of "nesting pointer for sub-agent
+loops" is dropped. Nesting is instead expressed through the
+`prev_step_id` tree — `prev_step_id` is not a linear successor pointer
+but a **tree edge**: a single step can be the predecessor of multiple
+children. A tool_call that dispatches a sub-agent has two successors:
+
+- the **sub-agent's head step** (a `model_call` that runs against
+  whatever model the sub-agent is configured for), and
+- the **outer continuation** (the next step in the user-visible
+  response, run after the sub-agent returns its result).
+
+All steps — including everything inside a sub-agent invocation — share
+the same `parent_step_id` (the user-visible head's id), so the
+listing-query anti-join still excludes their `request_id`s correctly
+and the chain-walk index `(parent_step_id, step_sequence)` returns
+every step of the response in one range scan. Walking the tree
+shape is then a client-side traversal of `prev_step_id` from the head,
+ordered within each branch by `step_sequence`.
+
+#### Why the chain idempotency constraint goes away
+
+Branching also occurs in the basic (non-nested) flow whenever a
+`model_call` returns multiple `tool_calls` — N `tool_call` children
+share `(root, model_call_id, 'tool_call')`. So branching is intrinsic
+to the data model, not just a sub-agent feature. Any
+`(parent_step_id, prev_step_id, step_kind)` unique constraint rejects
+ordinary parallel tool calls.
+
+Idempotency falls entirely to the transition function's chain-walk
+frontier check in `next_action_for`: walk the existing chain, only
+emit successors that aren't already present. The migration
+section above documents the constraint drop alongside the rest of
+the schema change.
+
+## Schema migration
+
+```sql
+-- 1. request_id becomes nullable (tool_call steps).
+ALTER TABLE response_steps
+    ALTER COLUMN request_id DROP NOT NULL;
+
+-- 2. Drop the chain idempotency constraint entirely (see "Why the
+-- chain idempotency constraint goes away" above).
+ALTER TABLE response_steps
+    DROP CONSTRAINT response_steps_chain_unique;
+
+-- 3. 1:1 between a model_call step and its sub-request fusillade row.
+-- Doubles as the FK-supporting index for request_id lookups, replacing
+-- the role response_steps_chain used to play.
+CREATE UNIQUE INDEX response_steps_request_id_unique
+    ON response_steps (request_id)
+    WHERE request_id IS NOT NULL;
+
+-- 4. Drop the old chain index (anchored on old request_id semantic).
+DROP INDEX IF EXISTS response_steps_chain;
+
+-- 5. New chain walk index: from a head step's id, range-scan every
+-- non-head step in the chain by step_sequence. Used by GET
+-- /v1/responses/{id} (tree assembly) and by next_action_for (frontier
+-- discovery during crash-recovery resume).
+CREATE INDEX response_steps_chain_walk
+    ON response_steps (parent_step_id, step_sequence)
+    WHERE parent_step_id IS NOT NULL;
+
+-- 6. Drop the simple parent_step_id index — subsumed by chain_walk.
+DROP INDEX IF EXISTS response_steps_parent;
+```
+
+The `response_steps_prev` partial index on `prev_step_id` stays as-is —
+it still serves frontier-detection during crash recovery.
+
+### Rationale: which indexes, where
+
+The dashboard's responses listing is the perf-critical query because:
+
+- **Cardinality.** `requests` is the largest table (one row per
+  upstream HTTP fire; multi-step + single-step combined). A multi-step
+  chain of N model_calls inflates row count by N×.
+- **Frequency.** Every dashboard refresh + every API list call. Cold
+  scan would be ruinous on production data.
+
+Two query forms support that listing — both work, both are O(scanned
+requests × index_lookup):
+
+```sql
+-- Anti-join (preferred)
+SELECT r.* FROM requests r
+WHERE NOT EXISTS (
+    SELECT 1 FROM response_steps s
+    WHERE s.request_id = r.id
+      AND s.parent_step_id IS NOT NULL
+)
+ORDER BY r.created_at DESC LIMIT N;
+
+-- LEFT JOIN with NULL filter (equivalent plan)
+SELECT r.* FROM requests r
+LEFT JOIN response_steps s
+    ON s.request_id = r.id AND s.parent_step_id IS NOT NULL
+WHERE s.id IS NULL
+ORDER BY r.created_at DESC LIMIT N;
+```
+
+Both use the unique partial index `response_steps_request_id_unique`
+to confirm presence/absence in O(log n). Postgres applies the
+`parent_step_id IS NOT NULL` predicate after fetching the matching
+row from the index — but because `request_id` is unique, only one row
+is fetched per request, making the per-request overhead constant.
+
+We considered a more specialized partial index
+`(request_id) WHERE parent_step_id IS NOT NULL AND request_id IS NOT NULL`
+but rejected it: the existing unique partial index already gives O(log n)
+lookup, the filter step is constant-time, and the additional index
+would double the write cost of every step insert without measurable
+read-side benefit.
+
+The chain walk (`GET /v1/responses/{id}`) is read-light and small
+(one lookup + a small range scan): `response_steps_chain_walk`'s
+`(parent_step_id, step_sequence)` is naturally aligned to the access
+pattern.
+
+### `EXPLAIN` verification (pending)
+
+The migration ships with a follow-up `EXPLAIN ANALYZE` script run in
+staging against representative dataset sizes (target: 10M `requests`,
+2M `response_steps`) to confirm:
+
+1. Listing query: index scan on `requests` (`idx_requests_created_at`
+   or analogous) + nested loop with index-only-lookups against
+   `response_steps_request_id_unique` per row.
+2. Chain walk: PK lookup for head + index range on
+   `response_steps_chain_walk` returning ≤ 16 rows for typical chains.
+
+If the planner picks a sequential scan on either at production
+cardinalities, we'll add a covering composite or hint via a planner
+config knob.
+
+## Storage / write path
+
+### Sub-request row creation
+
+dwctl's `FusilladeResponseStore::record_step` for a `model_call`:
+
+1. Generate `sub_request_id = Uuid::new_v4()`.
+2. **Synchronously** call `Storage::create_single_request_batch` with
+   `request_id = sub_request_id` so the FK is satisfied at the
+   `response_steps` insert.
+3. Insert `response_steps` (`request_id = sub_request_id`,
+   `parent_step_id = head_step_id_or_NULL`, `prev_step_id = …`).
+4. Stash `sub_request_id` in a per-loop slot the wrapped `HttpClient`
+   reads.
+
+The synchronous variant differs from the realtime path's "enqueue
+underway job" (CreateResponseInput) optimization. The reason: the
+multi-step path is already blocking on multiple upstream HTTP fires
+serially — an extra DB round-trip per step is comparatively cheap, and
+synchronous creation eliminates the FK-violation race that otherwise
+forces FK relaxation. We can revisit and switch to the async pattern
+later if record_step latency becomes a bottleneck (deferred FK or
+explicit FK-drop would be the unblock).
+
+### `tool_call` steps
+
+`request_id = NULL`. `tool_call_analytics` already carries
+`response_step_id` (added in dwctl migration 096), so the per-step
+attribution path for tools is independent of `requests`.
+
+### Loop's HTTP fire
+
+dwctl wraps onwards' `HttpClient` with a per-loop adapter that, on each
+`request()` call, drains the per-loop "next request_id" slot set by
+`record_step` and injects `x-fusillade-request-id: <id>` on the
+outgoing request. The `responses_middleware` already short-circuits
+its own row creation when this header is present (line 71 of
+`middleware.rs`). The outlet's `complete-response` job updates the
+existing row.
+
+## Application changes (dwctl, summarized)
+
+Tracked in the dwctl PR; outlined here for plan completeness:
+
+1. **Drop the parent `/v1/responses` row creation** in the warm-path
+   helpers (`try_warm_path_*`).
+2. **Migrate** `assemble_response`, `list_chain`, `next_action_for`,
+   the daemon path's parent lookup, `GET /v1/responses/{id}`, and the
+   chain-shape integration tests from "key on parent request_id" to
+   "key on head step_id (parent_step_id NULL on the head)".
+3. **`record_step`** pre-generates `sub_request_id` + creates the
+   row + inserts the step.
+4. **Wrapped `HttpClient`** injects `x-fusillade-request-id` per
+   model_call HTTP fire.
+5. **Listing endpoint** filters via the anti-join above.
+
+## Risks
+
+- **Migration on a populated table.** `response_steps` is small in
+  production today (the feature is new and not yet broadly enabled),
+  so the partial-index rebuilds and constraint swaps are cheap. If
+  the table grows before this lands, switch to `CREATE INDEX
+  CONCURRENTLY` and `ALTER ... DROP CONSTRAINT` becomes online (still
+  O(table) for the constraint validation; consider `NOT VALID +
+  VALIDATE CONSTRAINT` if the row count grows).
+
+- **Crash mid-step (record vs HTTP fire).** With synchronous
+  sub-request row creation, a crash between step 2 and step 3 of
+  `record_step` leaves an orphan `requests` row with no
+  `response_steps` row pointing at it. This is harmless: the row is
+  in `processing` state with this onwards instance's daemon_id, and
+  fusillade's stale-daemon detection will reclaim it after
+  `stale_daemon_threshold_ms`. The SIGTERM drain (COR-353) accelerates
+  the typical case.
+
+- **`parent_step_id` semantic change for existing rows.** Any
+  `response_steps` rows already in production were inserted under the
+  old "nesting pointer" semantic. Pre-deploy: confirm `response_steps`
+  is empty in every environment receiving the migration (the feature
+  is gated behind the multi-step processor wiring; if the processor
+  has never been wired in an environment, the table is empty there).
+  If non-empty, hand-migrate or truncate before apply.
+
+## Out of scope
+
+- **Wiring sub-agent dispatch in the transition function.** The
+  schema *supports* nesting via `prev_step_id` branching (and parallel
+  `tool_call` siblings), but the loop's transition function still
+  emits one successor per chain-walk pass. Wiring branch-point
+  emission is a follow-up.
+- **Backfilling analytics for already-completed multi-step responses.**
+  The fix is forward-only.
+- **Changing the `resp_<id>` user-visible identifier scheme.** The
+  value binds to the head step's `id`, which is a UUID just like the
+  old parent request_id, so external consumers see the same shape.

--- a/migrations/20260430000000_response_steps_request_linkage.down.sql
+++ b/migrations/20260430000000_response_steps_request_linkage.down.sql
@@ -20,4 +20,7 @@ ALTER TABLE response_steps
     UNIQUE NULLS NOT DISTINCT (request_id, parent_step_id, prev_step_id, step_kind);
 
 ALTER TABLE response_steps
+    DROP CONSTRAINT response_steps_request_id_step_kind_check;
+
+ALTER TABLE response_steps
     ALTER COLUMN request_id SET NOT NULL;

--- a/migrations/20260430000000_response_steps_request_linkage.down.sql
+++ b/migrations/20260430000000_response_steps_request_linkage.down.sql
@@ -1,0 +1,23 @@
+-- Reverse the response_steps re-anchoring. Restores the schema to its
+-- 20260428000000_add_response_steps shape.
+--
+-- Pre-deploy: this rollback assumes any tool_call rows inserted under
+-- the new schema (with request_id NULL) have been hand-resolved before
+-- the migration runs. The NOT NULL re-add will fail otherwise.
+
+DROP INDEX IF EXISTS response_steps_chain_walk;
+DROP INDEX IF EXISTS response_steps_request_id_unique;
+
+CREATE INDEX IF NOT EXISTS response_steps_parent
+    ON response_steps (parent_step_id)
+    WHERE parent_step_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS response_steps_chain
+    ON response_steps (request_id, parent_step_id, step_sequence);
+
+ALTER TABLE response_steps
+    ADD CONSTRAINT response_steps_chain_unique
+    UNIQUE NULLS NOT DISTINCT (request_id, parent_step_id, prev_step_id, step_kind);
+
+ALTER TABLE response_steps
+    ALTER COLUMN request_id SET NOT NULL;

--- a/migrations/20260430000000_response_steps_request_linkage.up.sql
+++ b/migrations/20260430000000_response_steps_request_linkage.up.sql
@@ -1,0 +1,74 @@
+-- Re-anchor response_steps.request_id at the per-step sub-request
+-- fusillade row (the row created for that step's HTTP fire) instead
+-- of the parent /v1/responses request. parent_step_id becomes the
+-- chain identifier ("root_step_id"): NULL only on the head, the
+-- head's id on every other step in the chain.
+--
+-- See fusillade/docs/plans/2026-04-30-response-steps-request-linkage.md
+-- for the full design and rationale (including why the chain
+-- idempotency unique constraint is dropped rather than re-keyed —
+-- branching is intrinsic to the data model).
+
+-- 1. request_id becomes nullable. tool_call steps don't have a
+-- corresponding fusillade.requests row (tool dispatch goes through
+-- dwctl's HttpToolExecutor; analytics live in tool_call_analytics).
+-- Only model_call steps have a sub-request row.
+ALTER TABLE response_steps
+    ALTER COLUMN request_id DROP NOT NULL;
+
+-- 2. Drop the chain idempotency constraint.
+--
+-- Branching is intrinsic to the data model: a model_call returning
+-- multiple tool_calls (parallel tool dispatch — standard OpenAI shape)
+-- emits N tool_call children sharing
+-- (parent_step_id, model_call_id, 'tool_call'). Any (parent, prev,
+-- kind) uniqueness rejects this, regardless of sub-agent nesting.
+--
+-- Idempotency falls to the transition function's chain-walk frontier
+-- check in next_action_for: walk the existing chain, emit only the
+-- successors that aren't already there. A redundant duplicate row is
+-- observable (extra entries in the chain walk) and recoverable, not
+-- corrupting.
+ALTER TABLE response_steps
+    DROP CONSTRAINT response_steps_chain_unique;
+
+-- 3. 1:1 between a model_call step and its sub-request fusillade row.
+-- Doubles as the FK-supporting index for request_id lookups, replacing
+-- the role response_steps_chain used to play.
+CREATE UNIQUE INDEX response_steps_request_id_unique
+    ON response_steps (request_id)
+    WHERE request_id IS NOT NULL;
+
+-- 4. Drop the old chain index (anchored on the old request_id
+-- semantic where request_id was constant per chain).
+DROP INDEX IF EXISTS response_steps_chain;
+
+-- 5. New chain walk index. From a head step's id, range-scan all
+-- non-head steps that belong to that response in step_sequence
+-- order. Used by GET /v1/responses/{id} (full-tree assembly) and by
+-- next_action_for (frontier discovery during crash-recovery resume).
+--
+-- Partial (parent_step_id IS NOT NULL) keeps the index tight:
+-- - The head step is fetched separately by id (PK lookup), so it
+--   doesn't need this index;
+-- - Skipping head rows halves the index size for the typical 2-step
+--   response and shrinks index depth at the high end.
+CREATE INDEX response_steps_chain_walk
+    ON response_steps (parent_step_id, step_sequence)
+    WHERE parent_step_id IS NOT NULL;
+
+-- 6. Drop the simple parent_step_id index — subsumed by
+-- response_steps_chain_walk above (same partial predicate, additional
+-- ordering key).
+DROP INDEX IF EXISTS response_steps_parent;
+
+-- 7. Update the column comments to reflect the new semantics. Index
+-- comments already follow the migration's ordering.
+COMMENT ON COLUMN response_steps.request_id IS
+    'FK to fusillade.requests for the upstream HTTP fire that this step represents. NULL on tool_call steps (tool dispatch lives outside fusillade.requests; analytics live in tool_call_analytics). Unique among non-NULL values via response_steps_request_id_unique.';
+
+COMMENT ON COLUMN response_steps.parent_step_id IS
+    'Head step (root) of the user-visible response chain. NULL only on the head itself. Every non-head step in the chain — including parallel tool_call siblings and any sub-agent steps reached via prev_step_id branching — points at the same head id.';
+
+COMMENT ON COLUMN response_steps.prev_step_id IS
+    'Tree edge: the step that immediately precedes this one. Multiple steps may share a prev_step_id (parallel tool_calls; sub-agent head + outer continuation after a tool_call). Order within siblings is given by step_sequence.';

--- a/migrations/20260430000000_response_steps_request_linkage.up.sql
+++ b/migrations/20260430000000_response_steps_request_linkage.up.sql
@@ -16,6 +16,21 @@
 ALTER TABLE response_steps
     ALTER COLUMN request_id DROP NOT NULL;
 
+-- 1a. Enforce the per-kind nullability invariant at the DB level so
+-- get_step_by_request and analytics attribution can rely on it
+-- without runtime defensiveness:
+--   model_call ⇒ request_id IS NOT NULL  (the sub-request row this
+--                step's HTTP fire created — 1:1 with http_analytics)
+--   tool_call  ⇒ request_id IS NULL      (tool dispatch lives outside
+--                fusillade.requests; analytics live in
+--                tool_call_analytics keyed on response_step_id)
+ALTER TABLE response_steps
+    ADD CONSTRAINT response_steps_request_id_step_kind_check
+    CHECK (
+        (step_kind = 'model_call' AND request_id IS NOT NULL) OR
+        (step_kind = 'tool_call'  AND request_id IS NULL)
+    );
+
 -- 2. Drop the chain idempotency constraint.
 --
 -- Branching is intrinsic to the data model: a model_call returning

--- a/src/manager/response_step.rs
+++ b/src/manager/response_step.rs
@@ -140,7 +140,10 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
             .fetch_optional(pool)
             .await
             .map_err(|e| {
-                FusilladeError::Other(anyhow!("Failed to fetch response_step by request_id: {}", e))
+                FusilladeError::Other(anyhow!(
+                    "Failed to fetch response_step by request_id: {}",
+                    e
+                ))
             })?;
 
         row.as_ref().map(step_from_row).transpose()

--- a/src/manager/response_step.rs
+++ b/src/manager/response_step.rs
@@ -150,15 +150,24 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
     }
 
     async fn list_chain(&self, head_step_id: StepId) -> Result<Vec<ResponseStep>> {
-        // Returns the head + every descendant. The head row is fetched
-        // via PK lookup; descendants via the partial chain_walk index on
-        // (parent_step_id, step_sequence) WHERE parent_step_id IS NOT NULL.
+        // Returns the head + every descendant. The two arms each hit a
+        // different index, so they're written as a UNION ALL rather than
+        // an OR predicate (which can degenerate into a bitmap-or that
+        // ignores one of the indexes under planner pressure):
+        //   * head:        primary key lookup on `id`
+        //   * descendants: partial index `response_steps_chain_walk`
+        //                  on (parent_step_id, step_sequence) WHERE
+        //                  parent_step_id IS NOT NULL
+        // The two sets are disjoint (the head's parent_step_id is NULL
+        // by invariant, and descendants have a distinct id), so UNION
+        // ALL — cheaper than UNION's dedup — is correct.
         let pool = self.pools.write();
         let query = format!(
-            "SELECT {} FROM response_steps \
-             WHERE id = $1 OR parent_step_id = $1 \
+            "SELECT {cols} FROM response_steps WHERE id = $1 \
+             UNION ALL \
+             SELECT {cols} FROM response_steps WHERE parent_step_id = $1 \
              ORDER BY step_sequence ASC",
-            STEP_COLUMNS
+            cols = STEP_COLUMNS
         );
         let rows = sqlx::query(&query)
             .bind(head_step_id.0)

--- a/src/manager/response_step.rs
+++ b/src/manager/response_step.rs
@@ -27,7 +27,7 @@ pub use sqlx_pool_router::PoolProvider;
 ///
 /// All read methods on this impl route through the **write/primary**
 /// pool. The orchestration loop reads its own freshly-written rows on
-/// every iteration (e.g., `list_scope` after `create_step` to confirm the
+/// every iteration (e.g., `list_chain` after `create_step` to confirm the
 /// frontier under crash recovery), and read-replica lag would surface as
 /// `None` or stale rows. The dashboard, if it ever queries the
 /// `response_steps` table, should grow a separate replica-routed read
@@ -55,7 +55,7 @@ fn step_from_row(row: &sqlx::postgres::PgRow) -> Result<ResponseStep> {
 
     Ok(ResponseStep {
         id: StepId(row.get("id")),
-        request_id: RequestId(row.get("request_id")),
+        request_id: row.get::<Option<Uuid>, _>("request_id").map(RequestId),
         prev_step_id: row.get::<Option<Uuid>, _>("prev_step_id").map(StepId),
         parent_step_id: row.get::<Option<Uuid>, _>("parent_step_id").map(StepId),
         step_kind: kind,
@@ -102,7 +102,7 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
              VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(id)
-        .bind(input.request_id.0)
+        .bind(input.request_id.map(|r| r.0))
         .bind(input.prev_step_id.map(|s| s.0))
         .bind(input.parent_step_id.map(|s| s.0))
         .bind(input.step_kind.as_str())
@@ -128,38 +128,37 @@ impl<P: PoolProvider> ResponseStepStore for PostgresResponseStepManager<P> {
         row.as_ref().map(step_from_row).transpose()
     }
 
-    async fn list_chain(&self, request_id: RequestId) -> Result<Vec<ResponseStep>> {
+    async fn get_step_by_request(&self, request_id: RequestId) -> Result<Option<ResponseStep>> {
+        // Uses response_steps_request_id_unique partial index for O(log n) lookup.
         let pool = self.pools.write();
         let query = format!(
-            "SELECT {} FROM response_steps WHERE request_id = $1 ORDER BY step_sequence ASC",
+            "SELECT {} FROM response_steps WHERE request_id = $1",
             STEP_COLUMNS
         );
-        let rows = sqlx::query(&query)
+        let row = sqlx::query(&query)
             .bind(request_id.0)
-            .fetch_all(pool)
+            .fetch_optional(pool)
             .await
-            .map_err(|e| FusilladeError::Other(anyhow!("Failed to list response_steps: {}", e)))?;
+            .map_err(|e| {
+                FusilladeError::Other(anyhow!("Failed to fetch response_step by request_id: {}", e))
+            })?;
 
-        rows.iter().map(step_from_row).collect()
+        row.as_ref().map(step_from_row).transpose()
     }
 
-    async fn list_scope(
-        &self,
-        request_id: RequestId,
-        scope_parent: Option<StepId>,
-    ) -> Result<Vec<ResponseStep>> {
+    async fn list_chain(&self, head_step_id: StepId) -> Result<Vec<ResponseStep>> {
+        // Returns the head + every descendant. The head row is fetched
+        // via PK lookup; descendants via the partial chain_walk index on
+        // (parent_step_id, step_sequence) WHERE parent_step_id IS NOT NULL.
         let pool = self.pools.write();
-        // Postgres treats NULL parent_step_id as its own group; use IS NOT
-        // DISTINCT FROM so a NULL parameter matches NULL rows.
         let query = format!(
             "SELECT {} FROM response_steps \
-             WHERE request_id = $1 AND parent_step_id IS NOT DISTINCT FROM $2 \
+             WHERE id = $1 OR parent_step_id = $1 \
              ORDER BY step_sequence ASC",
             STEP_COLUMNS
         );
         let rows = sqlx::query(&query)
-            .bind(request_id.0)
-            .bind(scope_parent.map(|s| s.0))
+            .bind(head_step_id.0)
             .fetch_all(pool)
             .await
             .map_err(|e| FusilladeError::Other(anyhow!("Failed to list response_steps: {}", e)))?;

--- a/src/response_step.rs
+++ b/src/response_step.rs
@@ -114,10 +114,24 @@ impl StepState {
 }
 
 /// A row from the `response_steps` table.
+///
+/// `request_id` is `Some` for `model_call` steps (each model_call has a
+/// dedicated `requests` row created for its upstream HTTP fire) and `None`
+/// for `tool_call` steps (tool dispatch lives outside `requests`; the
+/// per-tool analytics live in `tool_call_analytics`).
+///
+/// `parent_step_id` is the chain identifier — it points at the head
+/// (root) step of the user-visible response. It is `None` only on the
+/// head itself.
+///
+/// `prev_step_id` is a tree edge: the step that immediately precedes
+/// this one. Multiple steps may share a `prev_step_id` (parallel
+/// tool_calls; or, when sub-agent dispatch is wired, the sub-agent's
+/// head + the outer continuation after a tool_call).
 #[derive(Debug, Clone, Serialize)]
 pub struct ResponseStep {
     pub id: StepId,
-    pub request_id: RequestId,
+    pub request_id: Option<RequestId>,
     pub prev_step_id: Option<StepId>,
     pub parent_step_id: Option<StepId>,
     pub step_kind: StepKind,
@@ -137,12 +151,18 @@ pub struct ResponseStep {
 
 /// Input to [`ResponseStepStore::create_step`].
 ///
-/// `step_sequence` is monotonic per `request_id` across all nesting levels and
-/// doubles as the `Last-Event-ID` cursor for top-level events. Callers
-/// (the orchestration loop) are responsible for picking the next sequence
-/// value — the storage layer does not enforce monotonicity beyond what the
-/// `UNIQUE (request_id, parent_step_id, prev_step_id, step_kind)` constraint
-/// implicitly provides.
+/// `step_sequence` is monotonic per chain (head step) across the whole
+/// response tree. Callers (the orchestration loop) are responsible for
+/// picking the next sequence value.
+///
+/// Idempotency under crash recovery is the caller's responsibility:
+/// walk the existing chain via [`ResponseStepStore::list_chain`] and
+/// only emit successors that aren't already present. There is no
+/// database-side unique constraint on `(parent_step_id, prev_step_id,
+/// step_kind)` — branching is intrinsic to the data model (a model_call
+/// returning multiple `tool_calls` emits sibling rows with that exact
+/// tuple identical), so any uniqueness on those columns rejects
+/// ordinary parallel tool dispatch.
 #[derive(Debug, Clone)]
 pub struct CreateStepInput {
     /// Optional pre-generated step UUID. When `Some`, becomes the step's
@@ -150,7 +170,9 @@ pub struct CreateStepInput {
     /// before the row is committed (e.g., emitting an SSE event with the
     /// step id while the row is still being inserted).
     pub id: Option<Uuid>,
-    pub request_id: RequestId,
+    /// FK to `requests.id` for the upstream HTTP fire this step
+    /// represents. `None` on `tool_call` steps.
+    pub request_id: Option<RequestId>,
     pub prev_step_id: Option<StepId>,
     pub parent_step_id: Option<StepId>,
     pub step_kind: StepKind,
@@ -169,36 +191,28 @@ pub struct CreateStepInput {
 pub trait ResponseStepStore: Send + Sync {
     /// Insert a new step in `pending` state.
     ///
-    /// The `UNIQUE (request_id, parent_step_id, prev_step_id, step_kind)`
-    /// constraint is the idempotency safety net: a re-running transition
-    /// function under crash recovery will not produce duplicate successor
-    /// rows. The conflict is reported through the store's normal error
-    /// path; callers that need idempotent recovery should detect the
-    /// duplicate via [`ResponseStepStore::list_scope`] (which is the
-    /// authoritative way to find the existing frontier under recovery)
-    /// rather than relying on parsing this error.
+    /// No database-side idempotency constraint. Callers that need
+    /// idempotent recovery should walk the chain first via
+    /// [`ResponseStepStore::list_chain`] and skip emission of
+    /// successors that already exist.
     async fn create_step(&self, input: CreateStepInput) -> Result<StepId>;
 
     /// Fetch a single step by id. Returns `None` if not present.
     async fn get_step(&self, id: StepId) -> Result<Option<ResponseStep>>;
 
-    /// List every step for a request, ordered by `step_sequence`.
-    ///
-    /// Includes both top-level and nested (sub-agent) steps. Callers that
-    /// only want the user-visible chain should filter on
-    /// `parent_step_id IS NULL`.
-    async fn list_chain(&self, request_id: RequestId) -> Result<Vec<ResponseStep>>;
+    /// Fetch the step (if any) whose `request_id` matches the given
+    /// fusillade request id. Used by analytics + outlet plumbing to
+    /// resolve "which step does this upstream HTTP fire belong to".
+    /// Returns `None` for `tool_call` steps (which don't carry a
+    /// `request_id`) and for any non-multi-step fusillade row.
+    async fn get_step_by_request(&self, request_id: RequestId) -> Result<Option<ResponseStep>>;
 
-    /// List steps inside a specific scope ordered by `step_sequence`.
+    /// List every step in a response chain identified by its head step.
     ///
-    /// `scope_parent` selects the chain: `None` = the top-level chain
-    /// (user-visible response), `Some(step_id)` = the sub-loop spawned by
-    /// that tool_call step.
-    async fn list_scope(
-        &self,
-        request_id: RequestId,
-        scope_parent: Option<StepId>,
-    ) -> Result<Vec<ResponseStep>>;
+    /// Includes the head itself + every descendant (parallel tool_calls
+    /// and any future sub-agent recursion via `prev_step_id` branching).
+    /// Ordered by `step_sequence`.
+    async fn list_chain(&self, head_step_id: StepId) -> Result<Vec<ResponseStep>>;
 
     /// Mark a `pending` step as `processing`, recording `started_at`.
     ///

--- a/tests/response_steps.rs
+++ b/tests/response_steps.rs
@@ -264,7 +264,13 @@ async fn get_step_by_request_finds_model_call_owner(pool: sqlx::PgPool) {
 
     // A non-step-bound request (e.g. a single-step chat/completions row) returns None.
     let unrelated = insert_request(&pool).await;
-    assert!(store.get_step_by_request(unrelated).await.unwrap().is_none());
+    assert!(
+        store
+            .get_step_by_request(unrelated)
+            .await
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[sqlx::test]

--- a/tests/response_steps.rs
+++ b/tests/response_steps.rs
@@ -124,6 +124,52 @@ async fn tool_call_step_has_null_request_id(pool: sqlx::PgPool) {
 }
 
 #[sqlx::test]
+async fn step_kind_request_id_check_constraint_rejects_invalid_combos(pool: sqlx::PgPool) {
+    // The DB-level CHECK constraint enforces:
+    //   model_call ⇒ request_id IS NOT NULL  (the sub-request fusillade row)
+    //   tool_call  ⇒ request_id IS NULL      (analytics live in tool_call_analytics)
+    // Without it, get_step_by_request and analytics attribution would
+    // have to defend against malformed rows at every read.
+    let head_request_id = insert_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    // model_call with NULL request_id is rejected.
+    let model_no_request = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: None,
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await;
+    assert!(
+        model_no_request.is_err(),
+        "model_call with NULL request_id should violate the CHECK constraint"
+    );
+
+    // tool_call with non-NULL request_id is rejected.
+    let tool_with_request = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(head_request_id),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ToolCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await;
+    assert!(
+        tool_with_request.is_err(),
+        "tool_call with non-NULL request_id should violate the CHECK constraint"
+    );
+}
+
+#[sqlx::test]
 async fn list_chain_returns_head_plus_descendants_in_order(pool: sqlx::PgPool) {
     let pools = TestDbPools::new(pool.clone()).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);

--- a/tests/response_steps.rs
+++ b/tests/response_steps.rs
@@ -1,9 +1,22 @@
 //! Integration tests for the response_steps storage layer.
 //!
 //! Each test gets a fresh sqlx pool via `#[sqlx::test]`, which automatically
-//! runs every migration in `migrations/`. We insert a parent request row by
+//! runs every migration in `migrations/`. We insert a minimal request row by
 //! hand (avoiding the full file/template/batch chain) since these tests are
 //! scoped to the response_step module only.
+//!
+//! The new semantics (see plan
+//! `docs/plans/2026-04-30-response-steps-request-linkage.md`):
+//!
+//! - `response_steps.request_id` is `Option<RequestId>` and points at the
+//!   sub-request fusillade row created for *this* step's HTTP fire (one
+//!   row per `model_call`); `None` for `tool_call` steps.
+//! - `parent_step_id` points at the head (root) step of the chain;
+//!   `None` only on the head itself.
+//! - `prev_step_id` is a tree edge — multiple steps may share one
+//!   (parallel tool_calls; sub-agent head + outer continuation).
+//! - There is no chain-uniqueness constraint; idempotency is the
+//!   transition function's responsibility (chain-walk frontier check).
 
 use fusillade::request::RequestId;
 use fusillade::response_step::{CreateStepInput, ResponseStepStore, StepKind, StepState};
@@ -11,9 +24,10 @@ use fusillade::{PostgresResponseStepManager, TestDbPools};
 use serde_json::json;
 use uuid::Uuid;
 
-/// Insert a minimal parent `requests` row so `response_steps.request_id`'s
-/// foreign key is satisfied. Returns the new request id.
-async fn insert_parent_request(pool: &sqlx::PgPool) -> RequestId {
+/// Insert a minimal `requests` row so `response_steps.request_id`'s FK is
+/// satisfied. Each call returns a fresh `RequestId` so callers can model
+/// "one fusillade row per model_call step" naturally.
+async fn insert_request(pool: &sqlx::PgPool) -> RequestId {
     let template_id = Uuid::new_v4();
     let request_id = Uuid::new_v4();
 
@@ -43,292 +57,354 @@ async fn insert_parent_request(pool: &sqlx::PgPool) -> RequestId {
 }
 
 #[sqlx::test]
-async fn create_and_fetch_top_level_step(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
+async fn create_and_fetch_head_step(pool: sqlx::PgPool) {
+    let request_id = insert_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
     let step_id = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(request_id),
             prev_step_id: None,
             parent_step_id: None,
             step_kind: StepKind::ModelCall,
             step_sequence: 1,
-            request_payload: json!({"prompt": "hello"}),
+            request_payload: json!({"messages": [{"role": "user", "content": "hi"}]}),
         })
         .await
-        .expect("create_step");
+        .unwrap();
 
-    let fetched = store
-        .get_step(step_id)
-        .await
-        .expect("get_step")
-        .expect("step exists");
-
-    assert_eq!(fetched.id, step_id);
-    assert_eq!(fetched.request_id, request_id);
-    assert_eq!(fetched.step_kind, StepKind::ModelCall);
-    assert_eq!(fetched.state, StepState::Pending);
-    assert_eq!(fetched.step_sequence, 1);
-    assert_eq!(fetched.retry_attempt, 0);
-    assert!(fetched.response_payload.is_none());
-    assert!(fetched.started_at.is_none());
-    assert_eq!(fetched.request_payload, json!({"prompt": "hello"}));
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.id, step_id);
+    assert_eq!(step.request_id, Some(request_id));
+    assert_eq!(step.parent_step_id, None);
+    assert_eq!(step.prev_step_id, None);
+    assert_eq!(step.step_kind, StepKind::ModelCall);
+    assert_eq!(step.state, StepState::Pending);
+    assert_eq!(step.step_sequence, 1);
 }
 
 #[sqlx::test]
-async fn list_chain_returns_steps_in_sequence_order(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
+async fn tool_call_step_has_null_request_id(pool: sqlx::PgPool) {
+    let head_request_id = insert_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
-    // Insert in reverse to confirm ordering is by step_sequence, not insert time
-    let step_3 = store
+    let head_id = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(head_request_id),
             prev_step_id: None,
             parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"messages": []}),
+        })
+        .await
+        .unwrap();
+
+    // tool_call step: request_id is None (tool dispatch lives outside requests).
+    let tool_step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: None,
+            prev_step_id: Some(head_id),
+            parent_step_id: Some(head_id),
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({"name": "get_weather", "args": {"city": "Paris"}}),
+        })
+        .await
+        .unwrap();
+
+    let step = store.get_step(tool_step_id).await.unwrap().unwrap();
+    assert_eq!(step.request_id, None);
+    assert_eq!(step.step_kind, StepKind::ToolCall);
+}
+
+#[sqlx::test]
+async fn list_chain_returns_head_plus_descendants_in_order(pool: sqlx::PgPool) {
+    let pools = TestDbPools::new(pool.clone()).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    // Head (model_call). request_id = first sub-request row.
+    let head_req = insert_request(&pool).await;
+    let head_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(head_req),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"step": "head"}),
+        })
+        .await
+        .unwrap();
+
+    // tool_call (no request_id).
+    let tool_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: None,
+            prev_step_id: Some(head_id),
+            parent_step_id: Some(head_id),
+            step_kind: StepKind::ToolCall,
+            step_sequence: 2,
+            request_payload: json!({"step": "tool"}),
+        })
+        .await
+        .unwrap();
+
+    // Second model_call (its own sub-request row).
+    let second_req = insert_request(&pool).await;
+    let _second_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(second_req),
+            prev_step_id: Some(tool_id),
+            parent_step_id: Some(head_id),
             step_kind: StepKind::ModelCall,
             step_sequence: 3,
-            request_payload: json!({"step": 3}),
+            request_payload: json!({"step": "second_model"}),
         })
         .await
         .unwrap();
 
-    let step_1 = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: None,
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 1,
-            request_payload: json!({"step": 1}),
-        })
-        .await
-        .unwrap();
-
-    let step_2 = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(step_1),
-            parent_step_id: None,
-            step_kind: StepKind::ModelCall,
-            step_sequence: 2,
-            request_payload: json!({"step": 2}),
-        })
-        .await
-        .unwrap();
-
-    let chain = store.list_chain(request_id).await.unwrap();
+    let chain = store.list_chain(head_id).await.unwrap();
     assert_eq!(chain.len(), 3);
-    assert_eq!(chain[0].id, step_1);
-    assert_eq!(chain[1].id, step_2);
-    assert_eq!(chain[2].id, step_3);
-    assert_eq!(chain[1].prev_step_id, Some(step_1));
+    assert_eq!(chain[0].step_sequence, 1);
+    assert_eq!(chain[0].id, head_id);
+    assert_eq!(chain[0].parent_step_id, None);
+    assert_eq!(chain[1].step_sequence, 2);
+    assert_eq!(chain[1].step_kind, StepKind::ToolCall);
+    assert_eq!(chain[1].parent_step_id, Some(head_id));
+    assert_eq!(chain[2].step_sequence, 3);
+    assert_eq!(chain[2].request_id, Some(second_req));
+    assert_eq!(chain[2].parent_step_id, Some(head_id));
 }
 
 #[sqlx::test]
-async fn list_scope_separates_top_level_from_sub_loop(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
-    let pools = TestDbPools::new(pool).await.unwrap();
+async fn list_chain_isolates_chains_from_one_another(pool: sqlx::PgPool) {
+    // Two independent responses: each is its own head + child. list_chain on
+    // one head must not return the other's steps.
+    let pools = TestDbPools::new(pool.clone()).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
-    // Top-level: a model_call followed by a tool_call (which spawns a sub-agent)
-    let top_1 = store
+    let r1 = insert_request(&pool).await;
+    let head1 = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(r1),
             prev_step_id: None,
             parent_step_id: None,
             step_kind: StepKind::ModelCall,
             step_sequence: 1,
-            request_payload: json!({"top": 1}),
+            request_payload: json!({"chain": 1}),
         })
         .await
         .unwrap();
-    let top_2 = store
+    let r1b = insert_request(&pool).await;
+    let _child1 = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
-            prev_step_id: Some(top_1),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 2,
-            request_payload: json!({"top": 2, "tool": "delegate"}),
-        })
-        .await
-        .unwrap();
-
-    // Sub-loop under top_2: a model_call.
-    let sub_1 = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: None,
-            parent_step_id: Some(top_2),
+            request_id: Some(r1b),
+            prev_step_id: Some(head1),
+            parent_step_id: Some(head1),
             step_kind: StepKind::ModelCall,
-            step_sequence: 3,
-            request_payload: json!({"sub": 1}),
+            step_sequence: 2,
+            request_payload: json!({"chain": 1, "step": "child"}),
         })
         .await
         .unwrap();
 
-    let top = store.list_scope(request_id, None).await.unwrap();
-    assert_eq!(top.len(), 2);
-    assert_eq!(top[0].id, top_1);
-    assert_eq!(top[1].id, top_2);
+    let r2 = insert_request(&pool).await;
+    let head2 = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(r2),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({"chain": 2}),
+        })
+        .await
+        .unwrap();
 
-    let sub = store.list_scope(request_id, Some(top_2)).await.unwrap();
-    assert_eq!(sub.len(), 1);
-    assert_eq!(sub[0].id, sub_1);
+    let chain1 = store.list_chain(head1).await.unwrap();
+    assert_eq!(chain1.len(), 2);
+    let chain2 = store.list_chain(head2).await.unwrap();
+    assert_eq!(chain2.len(), 1);
+    assert_eq!(chain2[0].id, head2);
+}
 
-    let other_scope = store.list_scope(request_id, Some(top_1)).await.unwrap();
-    assert!(other_scope.is_empty());
+#[sqlx::test]
+async fn get_step_by_request_finds_model_call_owner(pool: sqlx::PgPool) {
+    let head_req = insert_request(&pool).await;
+    let pools = TestDbPools::new(pool.clone()).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let head_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(head_req),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    let found = store.get_step_by_request(head_req).await.unwrap().unwrap();
+    assert_eq!(found.id, head_id);
+
+    // A non-step-bound request (e.g. a single-step chat/completions row) returns None.
+    let unrelated = insert_request(&pool).await;
+    assert!(store.get_step_by_request(unrelated).await.unwrap().is_none());
+}
+
+#[sqlx::test]
+async fn parallel_tool_calls_with_same_prev_succeed(pool: sqlx::PgPool) {
+    // Branch point: a model_call returning multiple tool_calls. All
+    // tool_call children share (parent_step_id, prev_step_id, step_kind);
+    // there is no DB-level uniqueness, so insertion should succeed.
+    let head_req = insert_request(&pool).await;
+    let pools = TestDbPools::new(pool.clone()).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let head_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(head_req),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
+
+    for seq in 2..=4 {
+        store
+            .create_step(CreateStepInput {
+                id: None,
+                request_id: None,
+                prev_step_id: Some(head_id),
+                parent_step_id: Some(head_id),
+                step_kind: StepKind::ToolCall,
+                step_sequence: seq,
+                request_payload: json!({"tool_index": seq - 2}),
+            })
+            .await
+            .unwrap_or_else(|e| panic!("parallel tool_call insert failed at seq {seq}: {e}"));
+    }
+
+    let chain = store.list_chain(head_id).await.unwrap();
+    assert_eq!(chain.len(), 4);
+    let tool_calls: Vec<_> = chain
+        .iter()
+        .filter(|s| s.step_kind == StepKind::ToolCall)
+        .collect();
+    assert_eq!(tool_calls.len(), 3);
 }
 
 #[sqlx::test]
 async fn lifecycle_transitions(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
+    let request_id = insert_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
     let step_id = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(request_id),
             prev_step_id: None,
             parent_step_id: None,
             step_kind: StepKind::ModelCall,
             step_sequence: 1,
-            request_payload: json!({"p": 1}),
+            request_payload: json!({}),
         })
         .await
         .unwrap();
 
-    store.mark_step_processing(step_id).await.unwrap();
-    let s = store.get_step(step_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Processing);
-    assert!(s.started_at.is_some());
+    assert_eq!(
+        store.get_step(step_id).await.unwrap().unwrap().state,
+        StepState::Pending
+    );
 
-    // mark_step_processing is idempotent — no error when already processing
+    store.mark_step_processing(step_id).await.unwrap();
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.state, StepState::Processing);
+    assert!(step.started_at.is_some());
+
+    // Idempotency: re-marking processing on an already-processing step is a no-op.
     store.mark_step_processing(step_id).await.unwrap();
 
     store
-        .complete_step(step_id, json!({"output": "ok"}))
+        .complete_step(step_id, json!({"result": "ok"}))
         .await
         .unwrap();
-    let s = store.get_step(step_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Completed);
-    assert_eq!(s.response_payload, Some(json!({"output": "ok"})));
-    assert!(s.completed_at.is_some());
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.state, StepState::Completed);
+    assert_eq!(step.response_payload, Some(json!({"result": "ok"})));
+    assert!(step.completed_at.is_some());
 
-    // Cannot complete an already-terminal step.
-    let err = store.complete_step(step_id, json!({})).await;
-    assert!(err.is_err());
+    // Completing again is rejected (terminal state).
+    let err = store
+        .complete_step(step_id, json!({"second": true}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not in completable state"));
 }
 
 #[sqlx::test]
 async fn fail_step_records_error_payload(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
+    let request_id = insert_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
     let step_id = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(request_id),
             prev_step_id: None,
             parent_step_id: None,
-            step_kind: StepKind::ToolCall,
+            step_kind: StepKind::ModelCall,
             step_sequence: 1,
-            request_payload: json!({"tool": "search"}),
+            request_payload: json!({}),
         })
         .await
         .unwrap();
 
-    store.mark_step_processing(step_id).await.unwrap();
-
-    let err_payload = json!({"type": "max_iterations_exceeded", "details": "stuck"});
-    store.fail_step(step_id, err_payload.clone()).await.unwrap();
-
-    let s = store.get_step(step_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Failed);
-    assert_eq!(s.error, Some(err_payload));
-    assert!(s.failed_at.is_some());
+    store
+        .fail_step(step_id, json!({"type": "upstream_error", "code": 503}))
+        .await
+        .unwrap();
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.state, StepState::Failed);
+    assert!(step.failed_at.is_some());
+    assert_eq!(
+        step.error,
+        Some(json!({"type": "upstream_error", "code": 503}))
+    );
 }
 
 #[sqlx::test]
 async fn cancel_step_records_canceled_at_and_blocks_terminal_transitions(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
-    let pools = TestDbPools::new(pool).await.unwrap();
-    let store = PostgresResponseStepManager::new(pools);
-
-    // Cancel directly from `pending` (the most common path: a request is
-    // canceled before its first step has been claimed by a worker).
-    let pending_id = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: None,
-            parent_step_id: None,
-            step_kind: StepKind::ModelCall,
-            step_sequence: 1,
-            request_payload: json!({}),
-        })
-        .await
-        .unwrap();
-
-    store.cancel_step(pending_id).await.unwrap();
-    let s = store.get_step(pending_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Canceled);
-    assert!(s.canceled_at.is_some());
-    assert!(s.started_at.is_none());
-
-    // Subsequent terminal transitions are rejected (canceled is terminal).
-    let err = store.complete_step(pending_id, json!({"x": 1})).await;
-    assert!(err.is_err(), "complete_step on canceled step must fail");
-    let err = store.fail_step(pending_id, json!({"x": 1})).await;
-    assert!(err.is_err(), "fail_step on canceled step must fail");
-    let err = store.cancel_step(pending_id).await;
-    assert!(err.is_err(), "second cancel_step must fail");
-
-    // Cancel after `processing` works too — this is the path taken when a
-    // batch is canceled while a worker is mid-flight.
-    let processing_id = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(pending_id),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 2,
-            request_payload: json!({}),
-        })
-        .await
-        .unwrap();
-    store.mark_step_processing(processing_id).await.unwrap();
-    store.cancel_step(processing_id).await.unwrap();
-    let s = store.get_step(processing_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Canceled);
-    assert!(s.started_at.is_some());
-    assert!(s.canceled_at.is_some());
-}
-
-#[sqlx::test]
-async fn requeue_for_retry_increments_attempt(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
+    let request_id = insert_request(&pool).await;
     let pools = TestDbPools::new(pool).await.unwrap();
     let store = PostgresResponseStepManager::new(pools);
 
     let step_id = store
         .create_step(CreateStepInput {
             id: None,
-            request_id,
+            request_id: Some(request_id),
             prev_step_id: None,
             parent_step_id: None,
             step_kind: StepKind::ModelCall,
@@ -338,148 +414,43 @@ async fn requeue_for_retry_increments_attempt(pool: sqlx::PgPool) {
         .await
         .unwrap();
 
+    store.cancel_step(step_id).await.unwrap();
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.state, StepState::Canceled);
+    assert!(step.canceled_at.is_some());
+
+    // Subsequent terminal transitions are rejected.
+    let err = store
+        .complete_step(step_id, json!({}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not in completable state"));
+}
+
+#[sqlx::test]
+async fn requeue_for_retry_increments_attempt(pool: sqlx::PgPool) {
+    let request_id = insert_request(&pool).await;
+    let pools = TestDbPools::new(pool).await.unwrap();
+    let store = PostgresResponseStepManager::new(pools);
+
+    let step_id = store
+        .create_step(CreateStepInput {
+            id: None,
+            request_id: Some(request_id),
+            prev_step_id: None,
+            parent_step_id: None,
+            step_kind: StepKind::ModelCall,
+            step_sequence: 1,
+            request_payload: json!({}),
+        })
+        .await
+        .unwrap();
     store.mark_step_processing(step_id).await.unwrap();
+
     store.requeue_step_for_retry(step_id).await.unwrap();
-
-    let s = store.get_step(step_id).await.unwrap().unwrap();
-    assert_eq!(s.state, StepState::Pending);
-    assert_eq!(s.retry_attempt, 1);
-    assert!(s.started_at.is_none());
-
-    // Still pending — cannot requeue without going processing first.
-    let err = store.requeue_step_for_retry(step_id).await;
-    assert!(err.is_err());
-}
-
-#[sqlx::test]
-async fn unique_constraint_blocks_duplicate_successors(pool: sqlx::PgPool) {
-    let request_id = insert_parent_request(&pool).await;
-    let pools = TestDbPools::new(pool).await.unwrap();
-    let store = PostgresResponseStepManager::new(pools);
-
-    let parent = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: None,
-            parent_step_id: None,
-            step_kind: StepKind::ModelCall,
-            step_sequence: 1,
-            request_payload: json!({}),
-        })
-        .await
-        .unwrap();
-
-    // First successor: prev=parent, scope=top-level, kind=tool_call
-    store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(parent),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 2,
-            request_payload: json!({"first": true}),
-        })
-        .await
-        .unwrap();
-
-    // Re-running the transition function under crash recovery must not
-    // produce a duplicate row with the same (request, parent, prev, kind)
-    // tuple.
-    let dup = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(parent),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 3,
-            request_payload: json!({"first": false}),
-        })
-        .await;
-    assert!(
-        dup.is_err(),
-        "expected UNIQUE constraint violation on duplicate successor"
-    );
-
-    // Different step_kind under the same predecessor is fine.
-    store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(parent),
-            parent_step_id: None,
-            step_kind: StepKind::ModelCall,
-            step_sequence: 4,
-            request_payload: json!({}),
-        })
-        .await
-        .unwrap();
-}
-
-#[sqlx::test]
-async fn parallel_tool_calls_share_prev_but_unique_kinds(pool: sqlx::PgPool) {
-    // The orchestration loop fans out N tool_call rows after a model_call
-    // emits N tool calls. The UNIQUE constraint says
-    // (request_id, parent_step_id, prev_step_id, step_kind) must be
-    // unique, so multiple parallel tool_calls under the same predecessor
-    // are NOT allowed by this constraint alone — the storage layer relies
-    // on each parallel tool_call having a distinct prev_step_id chain
-    // (the fan-out linearizes them via prev_step_id pointing at the
-    // previous sibling, not all at the same parent).
-    //
-    // This test documents that intent: parallel siblings form a linear
-    // chain by prev_step_id, even though the orchestration loop fires
-    // their HTTP calls concurrently.
-
-    let request_id = insert_parent_request(&pool).await;
-    let pools = TestDbPools::new(pool).await.unwrap();
-    let store = PostgresResponseStepManager::new(pools);
-
-    let model = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: None,
-            parent_step_id: None,
-            step_kind: StepKind::ModelCall,
-            step_sequence: 1,
-            request_payload: json!({}),
-        })
-        .await
-        .unwrap();
-
-    let tool_a = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(model),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 2,
-            request_payload: json!({"tool": "a"}),
-        })
-        .await
-        .unwrap();
-
-    let tool_b = store
-        .create_step(CreateStepInput {
-            id: None,
-            request_id,
-            prev_step_id: Some(tool_a),
-            parent_step_id: None,
-            step_kind: StepKind::ToolCall,
-            step_sequence: 3,
-            request_payload: json!({"tool": "b"}),
-        })
-        .await
-        .unwrap();
-
-    let chain = store.list_chain(request_id).await.unwrap();
-    assert_eq!(chain.len(), 3);
-    assert_eq!(chain[0].id, model);
-    assert_eq!(chain[1].id, tool_a);
-    assert_eq!(chain[2].id, tool_b);
-    assert_eq!(chain[2].prev_step_id, Some(tool_a));
+    let step = store.get_step(step_id).await.unwrap().unwrap();
+    assert_eq!(step.state, StepState::Pending);
+    assert_eq!(step.retry_attempt, 1);
+    assert!(step.started_at.is_none());
 }


### PR DESCRIPTION
## Summary

Re-anchor `response_steps.request_id` to point at the **sub-request fusillade row created for that step's HTTP fire** (1:1 with `http_analytics`), instead of the parent /v1/responses request. `parent_step_id` becomes the chain identifier (NULL only on the head). Drops the parent /v1/responses fusillade row entirely — the response is purely the chain.

The dwctl side currently fans out every model_call into its own loopback /v1/chat/completions, each producing a fresh requests + http_analytics row. Without this change, those rows have no link back to the user-visible response, so token counts and costs report zero for every multi-step response. After this PR, each model_call step is 1:1 with its sub-request row and the dashboard can either filter sub-requests out of the responses view (anti-join on `parent_step_id IS NOT NULL`) or aggregate per-step analytics.

See [docs/plans/2026-04-30-response-steps-request-linkage.md](docs/plans/2026-04-30-response-steps-request-linkage.md) for the full design, index rationale, and migration plan.

## Schema migration

- `request_id` becomes nullable (tool_call steps don't have a fusillade row).
- Drop `response_steps_chain_unique` — branching is intrinsic (a model_call returning multiple `tool_calls` emits siblings sharing `(parent, prev, kind)`); idempotency moves to the transition function's chain-walk frontier check.
- New partial unique index on `(request_id) WHERE request_id IS NOT NULL` (1:1).
- New chain-walk index on `(parent_step_id, step_sequence) WHERE parent_step_id IS NOT NULL` for `GET /v1/responses/{id}` tree assembly.
- Drop the old `(request_id, parent_step_id, step_sequence)` and the simple `parent_step_id` partial — both subsumed.

## Trait changes (breaking)

- `ResponseStep.request_id`, `CreateStepInput.request_id` → `Option<RequestId>`
- New `get_step_by_request(RequestId) → Option<ResponseStep>` for analytics/outlet "which step does this HTTP fire belong to?" lookup.
- `list_chain(RequestId)` → `list_chain(StepId)` — pass the head step's id; returns head + every descendant in `step_sequence` order.
- `list_scope` removed — every descendant in a chain shares `parent_step_id = head`, so a single `list_chain` covers all the queries `list_scope` used to serve.

## Test plan
- [x] All 10 integration tests in tests/response_steps.rs pass against migrated schema (locally validated)
- [x] `cargo sqlx prepare` regenerated; offline cache up to date
- [ ] Pair with the dwctl PR (control-layer #1036, branch feat/multi-step-bridge) which consumes the new trait + populates analytics