### PR TITLE
fix: filter out-of-window requests before joining to batches table, keep batch_id in active batches index so we can use it to join to requests

### DIFF
--- a/migrations/20260506000000_batches_expiration_include_id.down.sql
+++ b/migrations/20260506000000_batches_expiration_include_id.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_batches_active_expiration_with_id;
+
+CREATE INDEX IF NOT EXISTS idx_batches_active_by_expiration
+  ON batches (expires_at ASC)
+  WHERE cancelling_at IS NULL;
+
+COMMENT ON INDEX idx_batches_active_by_expiration IS
+'Optimized for SLA-based queries: filters non-cancelled batches and sorts by expiration time';

--- a/migrations/20260506000000_batches_expiration_include_id.up.sql
+++ b/migrations/20260506000000_batches_expiration_include_id.up.sql
@@ -1,0 +1,23 @@
+-- Add an id-covering version of idx_batches_active_by_expiration so the
+-- pending-request-counts query (and any other expires_at-driven join on
+-- batch id) can satisfy the join key from the index alone, avoiding ~500K
+-- heap fetches per call in production.
+--
+-- Production deploy: build the new index CONCURRENTLY first so this migration
+-- becomes a no-op on the CREATE side. The DROP of the old index is fine in
+-- a regular transaction (brief ACCESS EXCLUSIVE lock):
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_batches_active_expiration_with_id
+--     ON batches (expires_at)
+--     INCLUDE (id)
+--     WHERE cancelling_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_batches_active_expiration_with_id
+  ON batches (expires_at)
+  INCLUDE (id)
+  WHERE cancelling_at IS NULL;
+
+COMMENT ON INDEX idx_batches_active_expiration_with_id IS
+'Active-batch expiration index with id INCLUDEd to enable index-only scans for joins keyed on batch id';
+
+DROP INDEX IF EXISTS idx_batches_active_by_expiration;

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -853,6 +853,11 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             WHERE r.state = ANY($5)
             AND r.template_id IS NOT NULL
             AND b.cancelling_at IS NULL
+            -- Row-level upper bound: a row that expires after every window's
+            -- end can't contribute to any window's COUNT FILTER, so prune it
+            -- here. Without this, the join reads every active+templated
+            -- request and only filters inside the aggregate.
+            AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
             AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
             AND (
                 $9 = 'any'


### PR DESCRIPTION
## The issue

`GET /admin/api/v1/monitoring/pending-request-counts` was taking 40+ seconds in production. The query underneath answers "for each model, how many active requests belong to a batch expiring in the next 24h" - straightforward, but the deadline check (`b.expires_at < NOW() + 24h`) lived inside `COUNT(*) FILTER`, so it ran *after* the join. Postgres dutifully joined every active+templated request (~1M) to its batch and only then discarded the out-of-window rows. The bitmap on `requests` went lossy and ended up reading ~6 GB of heap pages.

## Fix 1 - SQL change

Lift the deadline predicate out of `COUNT(*) FILTER` and into the `WHERE` clause:

```sql
AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
```

Same semantics (a row that fails this can't contribute to any window's count), but the planner now drives the join from `idx_batches_active_by_expiration` - the small side - instead of bitmap-scanning every active request. **41s -> 7.7s** on prod data.

## Fix 2 - Index change

The remaining bottleneck became the batches-side scan: ~500K heap fetches just to read `b.id` back so it could be joined against `r.batch_id`. The fix is to add `INCLUDE (id)` to that index so `id` sits alongside each entry and the planner can do an Index-Only Scan:

```sql
CREATE INDEX idx_batches_active_expiration_with_id
  ON batches(expires_at)
  INCLUDE (id)
  WHERE cancelling_at IS NULL;
```

(Plus dropping the old narrower index it supersedes.) Expected to take **7.7s -> ~1-2s**.