### PR TITLE
fix: distinguish RequestNotFound from RequestStateConflict in complete/fail

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,20 @@ pub enum FusilladeError {
     #[error("Request not found: {0}")]
     RequestNotFound(RequestId),
 
+    /// Request exists but is not in the expected state for the requested
+    /// operation (e.g., completing an already-completed or failed request).
+    ///
+    /// Distinct from [`RequestNotFound`] so callers can be properly idempotent
+    /// against concurrent writers — e.g. a complete-then-complete race where
+    /// the second caller should treat "already completed" as success rather
+    /// than synthesizing a new row.
+    #[error("Request {id} is in state '{current_state}', expected one of: {expected}")]
+    RequestStateConflict {
+        id: RequestId,
+        current_state: String,
+        expected: &'static str,
+    },
+
     /// Cancelled request
     #[error("Request cancelled: {0}")]
     RequestCancelled(RequestId),

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -3862,28 +3862,45 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         let pool = self.pools.write();
         let size = response_body.len() as i64;
 
-        let result = sqlx::query(
-            "UPDATE requests
-             SET state = 'completed',
-                 response_status = $2,
-                 response_body = $3,
-                 response_size = $4,
-                 completed_at = NOW()
-             WHERE id = $1 AND state = 'processing'",
+        // Try the UPDATE; if it doesn't match, surface whether the row is
+        // missing or just in the wrong state. The previous "0 rows → NotFound"
+        // signal collapsed those cases together, which made callers unable to
+        // distinguish a genuine missing row from a row that another writer had
+        // already moved out of 'processing'. Concurrent completers (zombie
+        // task replays, duplicate enqueues) hit the wrong-state case routinely.
+        let row: Option<(bool, Option<String>)> = sqlx::query_as(
+            "WITH updated AS (
+                 UPDATE requests
+                    SET state = 'completed',
+                        response_status = $2,
+                        response_body = $3,
+                        response_size = $4,
+                        completed_at = NOW()
+                  WHERE id = $1 AND state = 'processing'
+                 RETURNING 1
+             )
+             SELECT EXISTS(SELECT 1 FROM updated) AS matched,
+                    (SELECT state FROM requests WHERE id = $1) AS current_state
+             WHERE EXISTS(SELECT 1 FROM requests WHERE id = $1)",
         )
         .bind(request_id.0)
         .bind(status_code as i16)
         .bind(response_body)
         .bind(size)
-        .execute(pool)
+        .fetch_optional(pool)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to complete request: {}", e)))?;
 
-        if result.rows_affected() == 0 {
-            return Err(FusilladeError::RequestNotFound(request_id));
+        match row {
+            Some((true, _)) => Ok(()),
+            Some((false, Some(current_state))) => Err(FusilladeError::RequestStateConflict {
+                id: request_id,
+                current_state,
+                expected: "processing",
+            }),
+            // Fallback: row vanished between the CTE and the SELECT, or no row exists.
+            Some((false, None)) | None => Err(FusilladeError::RequestNotFound(request_id)),
         }
-
-        Ok(())
     }
 
     async fn fail_request(
@@ -3903,26 +3920,36 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         })?;
 
         let error_size = error_json.len() as i64;
-        let result = sqlx::query(
-            "UPDATE requests
-             SET state = 'failed',
-                 error = $2,
-                 response_size = $3,
-                 failed_at = NOW()
-             WHERE id = $1 AND state = 'processing'",
+        let row: Option<(bool, Option<String>)> = sqlx::query_as(
+            "WITH updated AS (
+                 UPDATE requests
+                    SET state = 'failed',
+                        error = $2,
+                        response_size = $3,
+                        failed_at = NOW()
+                  WHERE id = $1 AND state = 'processing'
+                 RETURNING 1
+             )
+             SELECT EXISTS(SELECT 1 FROM updated) AS matched,
+                    (SELECT state FROM requests WHERE id = $1) AS current_state
+             WHERE EXISTS(SELECT 1 FROM requests WHERE id = $1)",
         )
         .bind(request_id.0)
         .bind(&error_json)
         .bind(error_size)
-        .execute(pool)
+        .fetch_optional(pool)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fail request: {}", e)))?;
 
-        if result.rows_affected() == 0 {
-            return Err(FusilladeError::RequestNotFound(request_id));
+        match row {
+            Some((true, _)) => Ok(()),
+            Some((false, Some(current_state))) => Err(FusilladeError::RequestStateConflict {
+                id: request_id,
+                current_state,
+                expected: "processing",
+            }),
+            Some((false, None)) | None => Err(FusilladeError::RequestNotFound(request_id)),
         }
-
-        Ok(())
     }
 }
 

--- a/tests/complete_request_state_conflict.rs
+++ b/tests/complete_request_state_conflict.rs
@@ -1,0 +1,159 @@
+//! Regression tests for [`Storage::complete_request`] / [`Storage::fail_request`]
+//! disambiguating "row missing" from "row in wrong state".
+//!
+//! Background: previously both cases returned `RequestNotFound`, which made
+//! it impossible for callers (specifically `dwctl`'s `complete_response_idempotent`)
+//! to be properly idempotent against concurrent writers — a zombie task
+//! attempt completing the row out from under a fresh attempt looked
+//! identical to "row was never created".
+
+use fusillade::manager::Storage;
+use fusillade::{
+    CreateSingleRequestBatchInput, FusilladeError, MockHttpClient, PostgresRequestManager,
+    RequestId, TestDbPools,
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn manager(pool: sqlx::PgPool) -> Arc<PostgresRequestManager<TestDbPools, MockHttpClient>> {
+    Arc::new(PostgresRequestManager::with_client(
+        TestDbPools::new(pool).await.unwrap(),
+        Arc::new(MockHttpClient::new()),
+    ))
+}
+
+fn processing_input(request_id: Uuid) -> CreateSingleRequestBatchInput {
+    CreateSingleRequestBatchInput {
+        batch_id: None,
+        request_id,
+        body: r#"{"messages":[]}"#.to_string(),
+        model: "test-model".to_string(),
+        base_url: "http://localhost".to_string(),
+        endpoint: "/v1/chat/completions".to_string(),
+        completion_window: "0s".to_string(),
+        initial_state: "processing".to_string(),
+        api_key: None,
+        created_by: None,
+    }
+}
+
+#[sqlx::test]
+async fn complete_request_succeeds_for_processing_row(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+    m.create_single_request_batch(processing_input(id))
+        .await
+        .unwrap();
+
+    m.complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .expect("first complete_request should succeed");
+}
+
+#[sqlx::test]
+async fn complete_request_returns_state_conflict_when_already_completed(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+    m.create_single_request_batch(processing_input(id))
+        .await
+        .unwrap();
+    m.complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .unwrap();
+
+    let err = m
+        .complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .expect_err("second complete_request should error");
+
+    match err {
+        FusilladeError::RequestStateConflict {
+            id: got_id,
+            current_state,
+            expected,
+        } => {
+            assert_eq!(got_id, RequestId(id));
+            assert_eq!(current_state, "completed");
+            assert_eq!(expected, "processing");
+        }
+        other => panic!("expected RequestStateConflict, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn complete_request_returns_state_conflict_when_already_failed(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+    m.create_single_request_batch(processing_input(id))
+        .await
+        .unwrap();
+    m.fail_request(RequestId(id), "boom", 500).await.unwrap();
+
+    let err = m
+        .complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .expect_err("complete_request on a failed row should error");
+
+    match err {
+        FusilladeError::RequestStateConflict { current_state, .. } => {
+            assert_eq!(current_state, "failed");
+        }
+        other => panic!("expected RequestStateConflict, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn complete_request_returns_not_found_for_missing_row(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+
+    let err = m
+        .complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .expect_err("complete_request on missing row should error");
+
+    match err {
+        FusilladeError::RequestNotFound(got_id) => assert_eq!(got_id, RequestId(id)),
+        other => panic!("expected RequestNotFound, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn fail_request_returns_state_conflict_when_already_completed(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+    m.create_single_request_batch(processing_input(id))
+        .await
+        .unwrap();
+    m.complete_request(RequestId(id), r#"{"ok":true}"#, 200)
+        .await
+        .unwrap();
+
+    let err = m
+        .fail_request(RequestId(id), "boom", 500)
+        .await
+        .expect_err("fail_request on completed row should error");
+
+    match err {
+        FusilladeError::RequestStateConflict { current_state, .. } => {
+            assert_eq!(current_state, "completed");
+        }
+        other => panic!("expected RequestStateConflict, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn fail_request_returns_not_found_for_missing_row(pool: sqlx::PgPool) {
+    let m = manager(pool).await;
+    let id = Uuid::new_v4();
+
+    let err = m
+        .fail_request(RequestId(id), "boom", 500)
+        .await
+        .expect_err("fail_request on missing row should error");
+
+    match err {
+        FusilladeError::RequestNotFound(got_id) => assert_eq!(got_id, RequestId(id)),
+        other => panic!("expected RequestNotFound, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

`Storage::complete_request` and `Storage::fail_request` previously returned `RequestNotFound` for two completely distinct conditions:

1. The row genuinely doesn't exist.
2. The row exists but isn't in `processing` state (e.g. another writer already moved it to `completed` / `failed`).

Callers had no way to tell them apart, which made idempotency against concurrent writers impossible. This bit dwctl's responses pipeline in production / staging: a zombie underway task attempt completing the row out from under a fresh attempt looked identical to "row was never created", so the fresh attempt synthesized → hit a PK conflict → retried the UPDATE → still got `RequestNotFound`, and surfaced ``Failed to complete after create: Request not found`` to the operator.

This PR introduces a new error variant and adjusts both methods so callers can be properly idempotent.

## Changes

- New `FusilladeError::RequestStateConflict { id, current_state, expected }` variant. Surfaced when the row exists but isn't in the expected state for the operation.
- `complete_request` and `fail_request` now use a single CTE that:
  - performs the conditional UPDATE,
  - returns whether the UPDATE matched and what the row's current state is,
  - in one round-trip — no extra SELECT.
- `RequestNotFound` is now reserved for the genuinely-missing case.

## Breaking change

Adding a new variant to `FusilladeError` makes any exhaustive match on it non-exhaustive. The fusillade-internal usages are all non-exhaustive (`Err(... ::RequestNotFound(_)) => ...`) so they're unaffected, but the fusillade major contract changes — hence ``feat!:`` and bump to **16.9.0**.

dwctl is the known consumer; the matching control-layer PR is at https://github.com/doublewordai/control-layer/pull/new/fix/complete-response-idempotency and depends on this version landing on crates.io.

## Test plan

- [x] New `tests/complete_request_state_conflict.rs` covers:
  - happy path (UPDATE matches → ``Ok(())``)
  - `complete_request` on already-completed row → ``RequestStateConflict { current_state: "completed" }``
  - `complete_request` on already-failed row → ``RequestStateConflict { current_state: "failed" }``
  - `complete_request` on missing row → ``RequestNotFound``
  - `fail_request` on already-completed row → ``RequestStateConflict { current_state: "completed" }``
  - `fail_request` on missing row → ``RequestNotFound``
- [x] Existing daemon happy-path + retry tests still pass (`test_daemon_claims_and_completes_request`, `test_daemon_retries_failed_requests`)
- [ ] Full `just ci` run in CI

## Background

Failure pattern observed in staging on 2026-05-06: ~10 task attempts failed with the misleading `Request not found` message; the rows actually existed in `state='completed'` ~120ms after the failing attempt started. Reconstructed timeline pointed to underway-heartbeat-loss producing zombie attempt 1 workers that completed rows after underway had reclaimed them and started attempt 2. With this PR, callers can detect "already completed" and treat it as success rather than synthesizing.