### PR TITLE
feat: add priority_decay_window to Storage trait and PostgresRequestM…

### DIFF
--- a/migrations/20260528000000_add_pending_counts_indexes.down.sql
+++ b/migrations/20260528000000_add_pending_counts_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_requests_completed_flex_decay;
+DROP INDEX IF EXISTS idx_requests_active_non_priority_counts;

--- a/migrations/20260528000000_add_pending_counts_indexes.up.sql
+++ b/migrations/20260528000000_add_pending_counts_indexes.up.sql
@@ -1,9 +1,10 @@
 -- Indexes for get_pending_request_counts_by_model_and_window.
 --
 -- The normal queue-depth branch filters active templated requests, excludes
--- priority tier rows, joins by batch_id, and groups by model/window. A partial
--- index on exactly those countable active rows lets Postgres join from the
--- small batches table into matching requests without scanning all active rows.
+-- priority tier rows, groups by batch_id/model, and then applies expiry
+-- windows. A partial index on exactly those countable active rows, ordered by
+-- batch_id/model, lets Postgres perform that pre-aggregation as an index-only
+-- grouped scan.
 --
 -- The decay branch counts recently completed flex rows in the 1h bucket. The
 -- existing idx_requests_state index finds all completed rows and then filters
@@ -14,7 +15,7 @@
 -- migration so the IF NOT EXISTS statements become no-ops:
 --
 --   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_active_non_priority_counts
---   ON requests (batch_id) INCLUDE (model)
+--   ON requests (batch_id, model)
 --   WHERE state IN ('pending', 'claimed', 'processing')
 --     AND template_id IS NOT NULL
 --     AND (service_tier IS NULL OR service_tier <> 'priority');
@@ -26,7 +27,7 @@
 --     AND template_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_requests_active_non_priority_counts
-ON requests (batch_id) INCLUDE (model)
+ON requests (batch_id, model)
 WHERE state IN ('pending', 'claimed', 'processing')
   AND template_id IS NOT NULL
   AND (service_tier IS NULL OR service_tier <> 'priority');

--- a/migrations/20260528000000_add_pending_counts_indexes.up.sql
+++ b/migrations/20260528000000_add_pending_counts_indexes.up.sql
@@ -1,0 +1,38 @@
+-- Indexes for get_pending_request_counts_by_model_and_window.
+--
+-- The normal queue-depth branch filters active templated requests, excludes
+-- priority tier rows, joins by batch_id, and groups by model/window. A partial
+-- index on exactly those countable active rows lets Postgres join from the
+-- small batches table into matching requests without scanning all active rows.
+--
+-- The decay branch counts recently completed flex rows in the 1h bucket. The
+-- existing idx_requests_state index finds all completed rows and then filters
+-- by service_tier and completed_at; this partial index makes that branch
+-- selective by tier and completion time.
+--
+-- On large production tables, create these CONCURRENTLY before deploying this
+-- migration so the IF NOT EXISTS statements become no-ops:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_active_non_priority_counts
+--   ON requests (batch_id) INCLUDE (model)
+--   WHERE state IN ('pending', 'claimed', 'processing')
+--     AND template_id IS NOT NULL
+--     AND (service_tier IS NULL OR service_tier <> 'priority');
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_completed_flex_decay
+--   ON requests (completed_at DESC) INCLUDE (model)
+--   WHERE state = 'completed'
+--     AND service_tier = 'flex'
+--     AND template_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_active_non_priority_counts
+ON requests (batch_id) INCLUDE (model)
+WHERE state IN ('pending', 'claimed', 'processing')
+  AND template_id IS NOT NULL
+  AND (service_tier IS NULL OR service_tier <> 'priority');
+
+CREATE INDEX IF NOT EXISTS idx_requests_completed_flex_decay
+ON requests (completed_at DESC) INCLUDE (model)
+WHERE state = 'completed'
+  AND service_tier = 'flex'
+  AND template_id IS NOT NULL;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -310,6 +310,11 @@ pub trait Storage: Send + Sync {
     /// - `service_tier_filter`: filter on `service_tier`. `Any` (default) applies
     ///   no filter; `Include`/`Exclude` use `Option<String>` where `None`
     ///   represents the batch tier (`service_tier IS NULL`).
+    /// - `priority_decay_window`: optional lookback in seconds. When set,
+    ///   recently completed `service_tier = 'flex'` requests are added to
+    ///   the `"1h"` bucket so realtime traffic can decay out of scheduling
+    ///   pressure after successful completion. No effect if the requested
+    ///   windows do not include a `"1h"` label.
     /// - `strict`: bool. For critical/sensitive operations, set `true` to
     ///   use the write pool and avoid read lags.
     ///
@@ -322,6 +327,7 @@ pub trait Storage: Send + Sync {
         states: &[String],
         model_filter: &[String],
         service_tier_filter: &ServiceTierFilter,
+        priority_decay_window: Option<i64>,
         strict: bool,
     ) -> Result<HashMap<String, HashMap<String, i64>>>;
     ///

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -814,6 +814,8 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
 // Implement Storage trait directly (no delegation)
 #[async_trait]
 /// Returns counts of **claimable** pending requests grouped by model and expiry window.
+/// When `priority_decay_window` is set, recently completed flex requests
+/// are added to the `1h` bucket as an explicit realtime-load decay signal.
 ///
 /// This intentionally excludes:
 /// - Requests without a template (`template_id IS NULL`), which are not claimable.
@@ -828,10 +830,19 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         states: &[String], // e.g. ["pending"] or ["pending","claimed","processing"]
         model_filter: &[String], // empty = all models
         service_tier_filter: &ServiceTierFilter,
+        priority_decay_window: Option<i64>,
         strict: bool,
     ) -> Result<HashMap<String, HashMap<String, i64>>> {
         if windows.is_empty() || states.is_empty() {
             return Ok(HashMap::new());
+        }
+
+        if let Some(priority_decay_window) = priority_decay_window
+            && priority_decay_window < 0
+        {
+            return Err(FusilladeError::ValidationError(
+                "priority_decay_window must be non-negative".to_string(),
+            ));
         }
 
         // Indicator: i16 instead of bool because `Vec<bool>` doesn't have a
@@ -882,38 +893,66 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             r#"
             WITH windows(label, start_seconds, has_start, end_seconds) AS (
                 SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::int2[], $4::bigint[])
+            ),
+            batch_counts AS (
+                SELECT
+                    r.model as model,
+                    w.label as window_label,
+                    COUNT(*) FILTER (
+                        WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
+                          AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
+                    )::BIGINT as count
+                FROM requests r
+                JOIN batches b ON r.batch_id = b.id
+                CROSS JOIN windows w
+                WHERE r.state = ANY($5)
+                AND r.template_id IS NOT NULL
+                AND b.cancelling_at IS NULL
+                -- Row-level upper bound: a row that expires after every window's
+                -- end can't contribute to any window's COUNT FILTER, so prune it
+                -- here. Without this, the join reads every active+templated
+                -- request and only filters inside the aggregate.
+                AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
+                AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
+                AND (
+                    $9 = 'any'
+                    OR ($9 = 'include' AND (
+                        (r.service_tier IS NOT NULL AND r.service_tier = ANY($7))
+                        OR ($8 AND r.service_tier IS NULL)
+                    ))
+                    OR ($9 = 'exclude' AND (
+                        (r.service_tier IS NULL AND NOT $8)
+                        OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($7))
+                    ))
+                )
+                GROUP BY r.model, w.label
+            ),
+            priority_decay_counts AS (
+                SELECT
+                    r.model as model,
+                    '1h'::text as window_label,
+                    COUNT(*)::BIGINT as count
+                FROM requests r
+                WHERE $10::bigint IS NOT NULL
+                AND EXISTS (SELECT 1 FROM windows WHERE label = '1h')
+                AND r.service_tier = 'flex'
+                AND r.state = 'completed'
+                AND r.template_id IS NOT NULL
+                AND r.completed_at >= NOW() - make_interval(secs => $10::bigint)
+                AND r.completed_at <= NOW()
+                AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
+                GROUP BY r.model
             )
             SELECT
-                r.model as model,
-                w.label as window_label,
-                COUNT(*) FILTER (
-                    WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
-                      AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
-                )::BIGINT as count
-            FROM requests r
-            JOIN batches b ON r.batch_id = b.id
-            CROSS JOIN windows w
-            WHERE r.state = ANY($5)
-            AND r.template_id IS NOT NULL
-            AND b.cancelling_at IS NULL
-            -- Row-level upper bound: a row that expires after every window's
-            -- end can't contribute to any window's COUNT FILTER, so prune it
-            -- here. Without this, the join reads every active+templated
-            -- request and only filters inside the aggregate.
-            AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
-            AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
-            AND (
-                $9 = 'any'
-                OR ($9 = 'include' AND (
-                    (r.service_tier IS NOT NULL AND r.service_tier = ANY($7))
-                    OR ($8 AND r.service_tier IS NULL)
-                ))
-                OR ($9 = 'exclude' AND (
-                    (r.service_tier IS NULL AND NOT $8)
-                    OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($7))
-                ))
-            )
-            GROUP BY r.model, w.label
+                model,
+                window_label,
+                SUM(count)::BIGINT as count
+            FROM (
+                SELECT * FROM batch_counts
+                UNION ALL
+                SELECT * FROM priority_decay_counts
+            ) counts
+            GROUP BY model, window_label
             "#,
         )
         .bind(&labels)
@@ -925,6 +964,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .bind(&tier_names)
         .bind(tier_include_null)
         .bind(tier_mode)
+        .bind(priority_decay_window)
         .fetch_all(pool)
         .await
         .map_err(|e| {
@@ -11985,6 +12025,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12006,6 +12047,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12020,6 +12062,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12045,6 +12088,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12057,6 +12101,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12155,6 +12200,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12174,6 +12220,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12197,6 +12244,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12217,6 +12265,7 @@ mod tests {
                 &["pending".to_string()],
                 &[],
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12229,6 +12278,7 @@ mod tests {
                 &[],
                 &[],
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12311,6 +12361,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await
@@ -12324,6 +12375,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Exclude(vec![Some("priority".to_string())]),
+                None,
                 false,
             )
             .await
@@ -12337,6 +12389,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Include(vec![None]),
+                None,
                 false,
             )
             .await
@@ -12350,6 +12403,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Include(vec![None, Some("flex".to_string())]),
+                None,
                 false,
             )
             .await
@@ -12363,6 +12417,7 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Exclude(vec![None]),
+                None,
                 false,
             )
             .await
@@ -12376,11 +12431,202 @@ mod tests {
                 &states,
                 &model_filter,
                 &ServiceTierFilter::Include(vec![]),
+                None,
                 false,
             )
             .await
             .unwrap();
         assert!(counts.is_empty());
+    }
+
+    #[sqlx::test]
+    async fn test_pending_request_counts_priority_decay_window(pool: sqlx::PgPool) {
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let model = "flex-model";
+        let recent_id = Uuid::new_v4();
+        manager
+            .create_flex(CreateFlexInput {
+                request_id: recent_id,
+                body: r#"{"input":"recent"}"#.to_string(),
+                model: model.to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: "flex-user".to_string(),
+            })
+            .await
+            .unwrap();
+        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
+            .bind(recent_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        manager
+            .complete_request(RequestId(recent_id), r#"{"output":"recent"}"#, 200)
+            .await
+            .unwrap();
+
+        let old_id = Uuid::new_v4();
+        manager
+            .create_flex(CreateFlexInput {
+                request_id: old_id,
+                body: r#"{"input":"old"}"#.to_string(),
+                model: model.to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: "flex-user".to_string(),
+            })
+            .await
+            .unwrap();
+        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
+            .bind(old_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        manager
+            .complete_request(RequestId(old_id), r#"{"output":"old"}"#, 200)
+            .await
+            .unwrap();
+
+        let failed_id = Uuid::new_v4();
+        manager
+            .create_flex(CreateFlexInput {
+                request_id: failed_id,
+                body: r#"{"input":"failed"}"#.to_string(),
+                model: model.to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: "flex-user".to_string(),
+            })
+            .await
+            .unwrap();
+        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
+            .bind(failed_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        manager
+            .fail_request(RequestId(failed_id), r#"{"error":"failed"}"#, 500)
+            .await
+            .unwrap();
+
+        let canceled_id = Uuid::new_v4();
+        manager
+            .create_flex(CreateFlexInput {
+                request_id: canceled_id,
+                body: r#"{"input":"canceled"}"#.to_string(),
+                model: model.to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: "flex-user".to_string(),
+            })
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "UPDATE requests SET completed_at = NOW() - INTERVAL '5 minutes' WHERE id = $1",
+        )
+        .bind(recent_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE requests SET failed_at = NOW() - INTERVAL '5 minutes' WHERE id = $1")
+            .bind(failed_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE requests SET state = 'canceled', canceled_at = NOW() - INTERVAL '5 minutes' WHERE id = $1",
+        )
+        .bind(canceled_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE requests SET completed_at = NOW() - INTERVAL '11 minutes' WHERE id = $1",
+        )
+        .bind(old_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let windows = vec![
+            ("1h".to_string(), None, 3600),
+            ("24h".to_string(), None, 86_400),
+        ];
+        let states = vec![
+            "pending".to_string(),
+            "claimed".to_string(),
+            "processing".to_string(),
+        ];
+        let model_filter: Vec<String> = vec![];
+        let exclude_priority = ServiceTierFilter::Exclude(vec![Some("priority".to_string())]);
+
+        let counts_without_decay = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &exclude_priority,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(counts_without_decay.is_empty());
+
+        let counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &exclude_priority,
+                Some(600),
+                false,
+            )
+            .await
+            .unwrap();
+        let model_counts = counts.get(model).unwrap();
+        assert_eq!(*model_counts.get("1h").unwrap(), 1);
+        assert_eq!(model_counts.get("24h").copied().unwrap_or(0), 0);
+
+        let no_1h_counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &[("24h".to_string(), None, 86_400)],
+                &states,
+                &model_filter,
+                &exclude_priority,
+                Some(600),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(no_1h_counts.is_empty());
+
+        let err = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &exclude_priority,
+                Some(-1),
+                false,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("non-negative"));
     }
 
     // =========================================================================

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -12462,11 +12462,18 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
-            .bind(recent_id)
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "UPDATE requests
+             SET state = 'processing',
+                 daemon_id = gen_random_uuid(),
+                 claimed_at = NOW(),
+                 started_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(recent_id)
+        .execute(&pool)
+        .await
+        .unwrap();
         manager
             .complete_request(RequestId(recent_id), r#"{"output":"recent"}"#, 200)
             .await
@@ -12486,11 +12493,18 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
-            .bind(old_id)
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "UPDATE requests
+             SET state = 'processing',
+                 daemon_id = gen_random_uuid(),
+                 claimed_at = NOW(),
+                 started_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(old_id)
+        .execute(&pool)
+        .await
+        .unwrap();
         manager
             .complete_request(RequestId(old_id), r#"{"output":"old"}"#, 200)
             .await
@@ -12510,11 +12524,18 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE requests SET state = 'processing' WHERE id = $1")
-            .bind(failed_id)
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "UPDATE requests
+             SET state = 'processing',
+                 daemon_id = gen_random_uuid(),
+                 claimed_at = NOW(),
+                 started_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(failed_id)
+        .execute(&pool)
+        .await
+        .unwrap();
         manager
             .fail_request(RequestId(failed_id), r#"{"error":"failed"}"#, 500)
             .await

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -894,25 +894,14 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             WITH windows(label, start_seconds, has_start, end_seconds) AS (
                 SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::int2[], $4::bigint[])
             ),
-            batch_counts AS (
+            active_request_counts AS (
                 SELECT
-                    r.model as model,
-                    w.label as window_label,
-                    COUNT(*) FILTER (
-                        WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
-                          AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
-                    )::BIGINT as count
+                    r.batch_id,
+                    r.model,
+                    COUNT(*)::BIGINT AS request_count
                 FROM requests r
-                JOIN batches b ON r.batch_id = b.id
-                CROSS JOIN windows w
                 WHERE r.state = ANY($5)
                 AND r.template_id IS NOT NULL
-                AND b.cancelling_at IS NULL
-                -- Row-level upper bound: a row that expires after every window's
-                -- end can't contribute to any window's COUNT FILTER, so prune it
-                -- here. Without this, the join reads every active+templated
-                -- request and only filters inside the aggregate.
-                AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
                 AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
                 AND (
                     $9 = 'any'
@@ -925,7 +914,26 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                         OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($7))
                     ))
                 )
-                GROUP BY r.model, w.label
+                GROUP BY r.batch_id, r.model
+            ),
+            batch_counts AS (
+                SELECT
+                    arc.model as model,
+                    w.label as window_label,
+                    COALESCE(SUM(arc.request_count) FILTER (
+                        WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
+                          AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
+                    ), 0)::BIGINT as count
+                FROM active_request_counts arc
+                JOIN batches b ON arc.batch_id = b.id
+                CROSS JOIN windows w
+                WHERE b.cancelling_at IS NULL
+                -- Row-level upper bound: a row that expires after every window's
+                -- end can't contribute to any window's COUNT FILTER, so prune it
+                -- here. Without this, the join reads every active+templated
+                -- request and only filters inside the aggregate.
+                AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
+                GROUP BY arc.model, w.label
             ),
             priority_decay_counts AS (
                 SELECT

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2358,6 +2358,7 @@ mod queue_counts {
                 &["pending".to_string()],
                 &[],
                 &ServiceTierFilter::Any,
+                None,
                 false,
             )
             .await


### PR DESCRIPTION
This pull request introduces a new feature to the request manager: a "priority decay window" for flex service tier requests. This allows recently completed flex requests to be counted in the "1h" scheduling bucket, providing a way for flex traffic to cause less thrashing by being visible to scouter even after the requests are finished. The implementation includes changes to the SQL query, validation, trait signatures, and tests for the new functionality.

**Feature: Priority Decay Window for Flex Requests**

* Added an optional `priority_decay_window` parameter to the `Storage` trait and its implementations, allowing recently completed `service_tier = 'flex'` requests to be counted in the "1h" window for scheduling purposes. This helps smooth out scheduling pressure from realtime traffic. [[1]](diffhunk://#diff-50fe148ce34b2d4489a8c160a33049978bc570da98f21e7c933ef9f139c45bb7R313-R317) [[2]](diffhunk://#diff-50fe148ce34b2d4489a8c160a33049978bc570da98f21e7c933ef9f139c45bb7R330) [[3]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R833-R847)
* Updated the SQL query in `PostgresRequestManager` to union in counts of recently completed flex requests into the "1h" bucket when `priority_decay_window` is set and the "1h" window is requested. [[1]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38L885-R897) [[2]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R929-R955) [[3]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R967)

**Validation and Error Handling**

* Added validation to ensure that `priority_decay_window`, if provided, is non-negative, returning a validation error otherwise.

**Testing**

* Added a test (`test_pending_request_counts_priority_decay_window`) covering the new decay window logic, including edge cases for request states and window inclusion.
* Updated all relevant tests and integration tests to include the new `priority_decay_window` parameter, ensuring backwards compatibility and correctness. [[1]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12028) [[2]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12050) [[3]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12065) [[4]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12091) [[5]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12104) [[6]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12203) [[7]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12223) [[8]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12247) [[9]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12268) [[10]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12281) [[11]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12364) [[12]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12378) [[13]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12392) [[14]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12406) [[15]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R12420) [[16]](diffhunk://#diff-eb771f54a1fdc1c330a82981d7d27d1202a5cbe3a59581ff67af5e3361f5f90eR2361)

**Documentation**

* Updated doc comments to document the new parameter and its effects. [[1]](diffhunk://#diff-50fe148ce34b2d4489a8c160a33049978bc570da98f21e7c933ef9f139c45bb7R313-R317) [[2]](diffhunk://#diff-f91af752e03787b64fa890a3eebf492060fb6bd50b01995811f70b7159a41a38R817-R818)…anager