### PR TITLE
test: make flaky deadline retry tests robust to CI speed

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -854,11 +854,19 @@ async fn test_deadline_aware_retry_stops_before_deadline(pool: sqlx::PgPool) {
         let retry_count = failed.state.retry_attempt;
         let call_count = http_client.call_count();
 
-        // 1. Verify we stopped before too many retries (deadline constraint)
-        // Allow 7-9 attempts to account for timing variations in test execution
+        // 1. Verify we stopped before too many retries (deadline constraint).
+        // The exponential-backoff schedule — not CPU speed — caps how many
+        // retries fit before the deadline: each retry must wait its full backoff
+        // (tracked via a wall-clock `not_before`) before it can be re-claimed, so
+        // within the effective 1500ms deadline (2000ms window − 500ms buffer) at
+        // most 8 retries fit even with zero overhead. Slow/loaded CI overhead only
+        // eats into that window and yields *fewer* retries, never more. Hence a
+        // tight upper bound (the real deadline guard) and a generous lower bound
+        // (slack for slow runners).
         assert!(
-            (7..=9).contains(&retry_count),
-            "Expected 7-9 retry attempts based on deadline and backoff calculation, got {}",
+            (4..=8).contains(&retry_count),
+            "Expected 4-8 retry attempts (stops ~500ms before the 2000ms deadline; \
+             upper bound 8 is the backoff-schedule ceiling), got {}",
             retry_count
         );
 
@@ -1028,12 +1036,19 @@ async fn test_retry_stops_at_deadline_when_no_limits_set(pool: sqlx::PgPool) {
         let retry_count = failed.state.retry_attempt;
         let call_count = http_client.call_count();
 
-        // 1. Verify we retried more than the buffered case (which stopped at ~8)
-        //    but still stopped before too many attempts
-        // Allow 9-12 attempts to account for timing variations with CI slower CI CPUs
+        // 1. Verify retries continued until the deadline. As with the buffered
+        // deadline test above, the exponential-backoff schedule — not CPU speed —
+        // caps the retry count: each retry waits its full backoff (wall-clock
+        // `not_before`) before re-claim, so at most 11 fit within the 2000ms
+        // deadline (no buffer) even with zero overhead, and slow/loaded CI
+        // overhead only reduces that count, never increases it. So we keep a tight
+        // upper bound (the deadline guard) and a generous lower bound (slack for
+        // slow runners; a hard floor of 9 previously flaked when a loaded runner
+        // fit only ~8).
         assert!(
-            (9..12).contains(&retry_count),
-            "Expected 9-12 retry attempts (should retry until deadline with no buffer), got {}",
+            (5..=11).contains(&retry_count),
+            "Expected 5-11 retry attempts (retries until the 2000ms deadline, no buffer; \
+             upper bound 11 is the backoff-schedule ceiling), got {}",
             retry_count
         );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -854,35 +854,40 @@ async fn test_deadline_aware_retry_stops_before_deadline(pool: sqlx::PgPool) {
         let retry_count = failed.state.retry_attempt;
         let call_count = http_client.call_count();
 
-        // 1. Verify we stopped before too many retries (deadline constraint).
-        // The exponential-backoff schedule — not CPU speed — caps how many
-        // retries fit before the deadline: each retry must wait its full backoff
-        // (tracked via a wall-clock `not_before`) before it can be re-claimed, so
-        // within the effective 1500ms deadline (2000ms window − 500ms buffer) at
-        // most 8 retries fit even with zero overhead. Slow/loaded CI overhead only
-        // eats into that window and yields *fewer* retries, never more. Hence a
-        // tight upper bound (the real deadline guard) and a generous lower bound
-        // (slack for slow runners).
+        // max_retries is 10_000, so the *deadline* is what must stop the retries.
+        // Assert that invariant rather than an exact attempt count: the count is
+        // wall-clock dependent (how many DB/CPU cycles fit the window), so it
+        // varies with CI speed and was the source of the flakiness.
+
+        // It retried at least once before giving up.
         assert!(
-            (4..=8).contains(&retry_count),
-            "Expected 4-8 retry attempts (stops ~500ms before the 2000ms deadline; \
-             upper bound 8 is the backoff-schedule ceiling), got {}",
+            retry_count >= 1,
+            "expected at least one retry before the deadline, got {}",
             retry_count
         );
 
-        // 2. Verify HTTP call count matches retry attempts (1 initial + N retries)
+        // The 500ms buffer must stop the request *before* the batch expires.
+        assert!(
+            failed.state.failed_at < failed.state.batch_expires_at,
+            "buffered retry should stop before batch expiry: failed_at={}, expires_at={}",
+            failed.state.failed_at,
+            failed.state.batch_expires_at
+        );
+
+        // Exactly one HTTP call per attempt (1 initial + N retries).
         assert_eq!(
             call_count,
             (retry_count + 1) as usize,
-            "Expected call count to match retry attempts + 1 initial attempt, got {} calls for {} retry attempts",
-            call_count,
-            retry_count
+            "expected {} calls (1 initial + {} retries), got {}",
+            retry_count + 1,
+            retry_count,
+            call_count
         );
 
-        // 3. Verify the request actually has error details from the last attempt
+        // The terminal failure carries the last attempt's error.
         assert!(
             !failed.state.reason.to_error_message().is_empty(),
-            "Expected failed request to have failure reason"
+            "expected a failure reason"
         );
     } else {
         panic!(
@@ -1036,35 +1041,44 @@ async fn test_retry_stops_at_deadline_when_no_limits_set(pool: sqlx::PgPool) {
         let retry_count = failed.state.retry_attempt;
         let call_count = http_client.call_count();
 
-        // 1. Verify retries continued until the deadline. As with the buffered
-        // deadline test above, the exponential-backoff schedule — not CPU speed —
-        // caps the retry count: each retry waits its full backoff (wall-clock
-        // `not_before`) before re-claim, so at most 11 fit within the 2000ms
-        // deadline (no buffer) even with zero overhead, and slow/loaded CI
-        // overhead only reduces that count, never increases it. So we keep a tight
-        // upper bound (the deadline guard) and a generous lower bound (slack for
-        // slow runners; a hard floor of 9 previously flaked when a loaded runner
-        // fit only ~8).
+        // Neither max_retries nor a deadline buffer is set, so the SLA deadline is
+        // the only thing that can stop the retries. Assert that invariant rather
+        // than an exact attempt count: the count is wall-clock dependent (how many
+        // DB/CPU cycles fit the window), so it varies with CI speed and was the
+        // source of the flakiness.
+
+        // It retried at least once before giving up.
         assert!(
-            (5..=11).contains(&retry_count),
-            "Expected 5-11 retry attempts (retries until the 2000ms deadline, no buffer; \
-             upper bound 11 is the backoff-schedule ceiling), got {}",
+            retry_count >= 1,
+            "expected at least one retry before the deadline, got {}",
             retry_count
         );
 
-        // 2. Verify HTTP call count matches retry attempts (1 initial + N retries)
+        // With no buffer, retries run right up to the deadline: the final attempt
+        // fails within one backoff step (≤200ms) of batch expiry, not hundreds of
+        // ms early like the buffered case. 500ms slack absorbs scheduling jitter.
+        assert!(
+            failed.state.failed_at.timestamp_millis()
+                >= failed.state.batch_expires_at.timestamp_millis() - 500,
+            "no-buffer retry should run up to the deadline: failed_at={}, expires_at={}",
+            failed.state.failed_at,
+            failed.state.batch_expires_at
+        );
+
+        // Exactly one HTTP call per attempt (1 initial + N retries).
         assert_eq!(
             call_count,
             (retry_count + 1) as usize,
-            "Expected call count to match retry attempts + 1 initial attempt, got {} calls for {} retry attempts",
-            call_count,
-            retry_count
+            "expected {} calls (1 initial + {} retries), got {}",
+            retry_count + 1,
+            retry_count,
+            call_count
         );
 
-        // 3. Verify the request has error details from the last attempt
+        // The terminal failure carries the last attempt's error.
         assert!(
             !failed.state.reason.to_error_message().is_empty(),
-            "Expected failed request to have failure reason"
+            "expected a failure reason"
         );
     } else {
         panic!(


### PR DESCRIPTION
## Summary
Fixes the flaky `fusillade` deadline integration tests (`test_deadline_aware_retry_stops_before_deadline`, `test_retry_stops_at_deadline_when_no_limits_set`).

**Root cause:** they asserted the *number* of retries that fit in a fixed completion window, but that count is wall-clock dependent — backoff `not_before`, the `can_retry` deadline check, and the SQL claim filter all use `chrono::Utc::now()`. On a slow/loaded CI runner fewer retries fit, so a fixed range flakes (a recent run fit ~8 and tripped the `(9..12)` lower bound).

**Fix:** assert the *invariant* the deadline logic guarantees — independent of CPU speed — instead of a magic count range:
- **buffered** (`stop_before_deadline_ms = 500`): the request stops **before** the batch expires — `failed_at < batch_expires_at`.
- **no buffer**: retries run **up to** the deadline — `failed_at` is within one backoff step (≤200ms) of `batch_expires_at` (500ms slack for jitter).
- **both**: retried ≥ 1 time, exactly one HTTP call per attempt (`call_count == retry_count + 1`), and the terminal failure carries an error reason.

`tokio::time::pause()` was considered but doesn't apply — the path uses `chrono`/SQL wall-clock (not `tokio::time`) and runs against real Postgres under `#[sqlx::test]`; true determinism would require injecting a mock clock into production + SQL, out of scope here.

Test-only; no library behavior change. Standalone, unrelated to #276.

## Test plan
- [x] `cargo test --test integration` → 18/18 pass
- [x] Two deadline tests stable under single-core CPU starvation (8/8 runs, ~2x wall-time) — the new `failed_at` invariants hold under load
- [x] `cargo fmt --check` clean; `cargo clippy -- -D warnings` (CI's command) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)