### PR TITLE
fix: make populate_batch idempotent to prevent duplicate batch requests

### DIFF
--- a/.sqlx/query-1305a60bf24872a002b0f0522ba90144c1de5a77069b30633083ce2e807d72a4.json
+++ b/.sqlx/query-1305a60bf24872a002b0f0522ba90144c1de5a77069b30633083ce2e807d72a4.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                b.completion_window,\n                b.cancelling_at,\n                b.deleted_at AS batch_deleted_at,\n                (SELECT deleted_at FROM files WHERE id = $2) AS file_deleted_at\n            FROM batches b\n            WHERE b.id = $1\n            ",
+  "query": "\n            SELECT\n                b.completion_window,\n                b.cancelling_at,\n                b.requests_started_at,\n                b.deleted_at AS batch_deleted_at,\n                (SELECT deleted_at FROM files WHERE id = $2) AS file_deleted_at\n            FROM batches b\n            WHERE b.id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -15,11 +15,16 @@
       },
       {
         "ordinal": 2,
-        "name": "batch_deleted_at",
+        "name": "requests_started_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 3,
+        "name": "batch_deleted_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
         "name": "file_deleted_at",
         "type_info": "Timestamptz"
       }
@@ -34,8 +39,9 @@
       false,
       true,
       true,
+      true,
       null
     ]
   },
-  "hash": "760f0c906c8d9375681dd45695cec12fb28942b785105b524fb7d9dca4941759"
+  "hash": "1305a60bf24872a002b0f0522ba90144c1de5a77069b30633083ce2e807d72a4"
 }

--- a/.sqlx/query-b0b1efc58dc191cc0a29ec66d2a196c104162098ef8fffcdec9ccac473208968.json
+++ b/.sqlx/query-b0b1efc58dc191cc0a29ec66d2a196c104162098ef8fffcdec9ccac473208968.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock(hashtextextended('fusillade.populate_batch:' || $1::text, 0))",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b0b1efc58dc191cc0a29ec66d2a196c104162098ef8fffcdec9ccac473208968"
+}

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2999,15 +2999,36 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 FusilladeError::Other(anyhow!("Failed to begin transaction: {}", e))
             })?;
 
+        // Serialize population of the same batch. underway delivers the
+        // create-batch job at-least-once: the task can be reclaimed on
+        // heartbeat expiry and its step re-run, and (since the job sets no
+        // concurrency key) a batch can in principle be enqueued twice. This
+        // transaction-scoped advisory lock — auto-released on commit/rollback —
+        // lets only one populate run at a time *per batch* (different batches
+        // hash to different keys and never contend), so the idempotency guard
+        // below observes a committed prior population rather than racing it. It
+        // is a lightweight advisory lock on a hashed id, not a lock on the
+        // requests table, so it cannot block request writes.
+        sqlx::query!(
+            "SELECT pg_advisory_xact_lock(hashtextextended('fusillade.populate_batch:' || $1::text, 0))",
+            *batch_id as Uuid,
+        )
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| FusilladeError::Other(anyhow!("Failed to acquire populate lock: {}", e)))?;
+
         // Bail out if the batch (or its source file) has been cancelled or
         // deleted in the window since the batch was created — otherwise the
         // INSERT below can FK-violate against templates the purger has
-        // already removed.
+        // already removed. `requests_started_at` is read here too, to drive the
+        // idempotency guard below; both come from the batches table (one row by
+        // PK), so this does not touch the requests table.
         let row = sqlx::query!(
             r#"
             SELECT
                 b.completion_window,
                 b.cancelling_at,
+                b.requests_started_at,
                 b.deleted_at AS batch_deleted_at,
                 (SELECT deleted_at FROM files WHERE id = $2) AS file_deleted_at
             FROM batches b
@@ -3019,6 +3040,27 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fetch batch state: {}", e)))?;
+
+        // Idempotency: if this batch was already populated, do nothing.
+        // `requests_started_at` is set in the *same transaction* as the INSERT
+        // below, so a committed prior attempt makes it non-NULL while a failed
+        // attempt rolls it back to NULL. This is exactly what distinguishes a
+        // correct retry (prior attempt failed and rolled back → repopulate)
+        // from a duplicate run (prior attempt committed but the at-least-once
+        // job was re-delivered → skip). Without it, the re-delivered job re-runs
+        // the unconditional INSERT and duplicates every request while
+        // total_requests keeps the first run's value, wedging the batch in
+        // "finalizing" forever (terminal_count can never equal total_requests).
+        if row.requests_started_at.is_some() {
+            tx.commit().await.map_err(|e| {
+                FusilladeError::Other(anyhow!("Failed to commit transaction: {}", e))
+            })?;
+            tracing::info!(
+                batch_id = %batch_id,
+                "Batch already populated; skipping population (idempotent no-op)"
+            );
+            return Ok(());
+        }
 
         if row.batch_deleted_at.is_some() {
             // Deleted before population could run - nothing to populate. The delete
@@ -6990,6 +7032,46 @@ mod tests {
             .populate_batch(batch_id, file_id)
             .await
             .expect("populate_batch is a no-op after batch deleted");
+    }
+
+    // Regression test: underway delivers the create-batch job at-least-once, so
+    // a successful populate can be re-delivered (heartbeat-expiry reclaim, or a
+    // double enqueue since the job sets no concurrency key). Re-running populate
+    // must be a no-op, not a second full insert — otherwise the batch ends up
+    // with 2x request rows while total_requests keeps the first run's value,
+    // wedging it in "finalizing" forever (terminal_count never == total).
+    #[sqlx::test]
+    async fn test_populate_batch_is_idempotent(pool: sqlx::PgPool) {
+        let (manager, file_id, batch_id) = populate_guard_setup(pool).await;
+
+        // First population succeeds and snapshots the single template.
+        manager.populate_batch(batch_id, file_id).await.unwrap();
+        let after_first = manager.get_batch(batch_id).await.unwrap();
+        assert_eq!(
+            after_first.total_requests, 1,
+            "first populate should snapshot the one template"
+        );
+        assert_eq!(
+            manager.get_batch_requests(batch_id).await.unwrap().len(),
+            1,
+            "first populate should create exactly one request row"
+        );
+
+        // Re-delivery of the same job must not duplicate the requests.
+        manager.populate_batch(batch_id, file_id).await.expect(
+            "re-running populate_batch on an already-populated batch should succeed as a no-op",
+        );
+
+        let after_second = manager.get_batch(batch_id).await.unwrap();
+        assert_eq!(
+            after_second.total_requests, 1,
+            "re-population must not change total_requests"
+        );
+        assert_eq!(
+            manager.get_batch_requests(batch_id).await.unwrap().len(),
+            1,
+            "re-population must not create duplicate request rows"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## Problem

A production batch (`176b748b-…`) was stuck in `finalizing` forever, reporting **8368 completed requests for a 4184-input batch** — exactly 2×. Root-cause investigation showed the `create-batch` underway job ran its step **twice** (one task, two `succeeded` attempts ~31s apart — a heartbeat-expiry reclaim), and `populate_batch` inserted a full set of requests on **both** attempts.

`underway` is **at-least-once**: a task can be reclaimed on heartbeat expiry and re-run, and since the create-batch job sets **no `concurrency_key`**, a batch can in principle be enqueued twice. `populate_batch` was not idempotent:

- unconditional `INSERT … SELECT FROM request_templates`
- `total_requests = rows_affected` (overwrite, not sum)

So a re-delivery doubled the request rows while `total_requests` kept the first run's value. That permanently wedges the batch: `openai_status()` computes `terminal_count = completed + failed + canceled` (8368), which can never equal `total_requests` (4184), so it never flips to `completed` and the output file never finalizes.

Across all of prod this hit **2 of 43,645** batches (the other 9 multi-attempt tasks were correct retries — their first attempt failed and rolled back). Both affected batches have been de-duplicated manually; this PR prevents recurrence.

## Fix

Two cheap guards in `populate_batch`, neither of which reads or locks the hot `requests` table:

1. **Transaction-scoped advisory lock** keyed on the batch id (`pg_advisory_xact_lock(hashtextextended(...))`). Serializes concurrent populates of the *same* batch (different batches hash to different keys and never contend); auto-released on commit/rollback. It's an advisory lock on a hashed id — **not** a lock on `requests`.
2. **Idempotency guard on `batches.requests_started_at`**, which is set in the *same transaction* as the INSERT:
   - committed prior population ⇒ non-NULL ⇒ skip as a no-op
   - failed attempt ⇒ rolled back to NULL ⇒ repopulate (existing retry behaviour preserved)

Both reads come from `batches` (one row by PK), so the change adds **no read/lock on `requests`** and leaves the `total_requests = rows_affected` path untouched (it only runs on the genuine first population).

## Considered alternatives

- `UNIQUE(batch_id, template_id)` + `ON CONFLICT DO NOTHING` — rejected for now: building a unique index on the multi-million-row `requests` table (migrations can't use `CONCURRENTLY`) risks locking writes on deploy. Worth revisiting behind a maintenance window as defence-in-depth.
- Setting the job's `concurrency_key = batch_id` in dwctl — complementary hardening; can follow separately.

## Testing

- New regression test `test_populate_batch_is_idempotent`: re-runs `populate_batch` on an already-populated batch and asserts request count and `total_requests` stay at 1.
- Existing `test_populate_batch_rejects_when_{source_file,batch}_deleted` / `_cancelled` still pass (guard is placed before those checks but only triggers for already-populated batches, whose `requests_started_at` is non-NULL).
- `cargo test --lib populate_batch` → 4 passed. `cargo clippy` clean. `.sqlx` cache regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)