### PR TITLE
feat: standardise error logs into having metric emissions

### DIFF
--- a/src/bg_errors.rs
+++ b/src/bg_errors.rs
@@ -1,0 +1,44 @@
+//! Unified background-error metric and log for the fusillade daemon.
+//!
+//! `background_error!` emits the `fusillade_background_errors_total` counter AND a `tracing`
+//! event from one call site, so the metric and the log can never drift. Mirrors dwctl's
+//! `metrics::errors`. Named `bg_errors` (not `metrics`) to avoid shadowing the `metrics` crate
+//! at the fusillade crate root.
+//!
+//! fusillade has a single background `component` ("daemon"), so it is baked in here rather than
+//! passed at every call site. The `component` label is still emitted (so dashboards/queries
+//! stay parallel to dwctl); if a second component ever appears, add the arg back then.
+
+use metrics::counter;
+
+/// Increment `fusillade_background_errors_total{component="daemon", reason, severity}`.
+/// `reason`/`severity` are `&'static str` (string literals) - the type forbids dynamic labels.
+pub fn record(reason: &'static str, severity: &'static str) {
+    counter!(
+        "fusillade_background_errors_total",
+        "component" => "daemon",
+        "reason" => reason,
+        "severity" => severity
+    )
+    .increment(1);
+}
+
+/// Record a daemon background failure: increment the metric AND emit a `tracing` event, from
+/// one site. Severity is a literal tier token: `Critical` (error! + pages), `Error` (error!,
+/// no page), `Warning` (warn!, no page). `reason` must be a `&'static str` literal; trailing
+/// tokens are forwarded to `tracing` as fields and message.
+#[macro_export]
+macro_rules! background_error {
+    ($reason:expr, Critical, $($arg:tt)+) => {{
+        $crate::bg_errors::record($reason, "critical");
+        ::tracing::error!(component = "daemon", reason = $reason, $($arg)+);
+    }};
+    ($reason:expr, Error, $($arg:tt)+) => {{
+        $crate::bg_errors::record($reason, "error");
+        ::tracing::error!(component = "daemon", reason = $reason, $($arg)+);
+    }};
+    ($reason:expr, Warning, $($arg:tt)+) => {{
+        $crate::bg_errors::record($reason, "warning");
+        ::tracing::warn!(component = "daemon", reason = $reason, $($arg)+);
+    }};
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -462,8 +462,8 @@ where
                             Err(e) => {
                                 histogram!("fusillade_heartbeat_duration_seconds")
                                     .record(heartbeat_start.elapsed().as_secs_f64());
-                                counter!("fusillade_heartbeat_failures_total").increment(1);
-                                tracing::error!(
+                                crate::background_error!(
+                                    "heartbeat_failed", Error,
                                     daemon_id = %daemon_id,
                                     error = %e,
                                     "Failed to send heartbeat"
@@ -476,7 +476,8 @@ where
                         // Mark daemon as dead on shutdown
                         tracing::info!("Shutting down heartbeat task");
                         if let Err(e) = daemon_record.shutdown(storage.as_ref()).await {
-                            tracing::error!(
+                            crate::background_error!(
+                                "shutdown_mark_failed", Error,
                                 daemon_id = %daemon_id,
                                 error = %e,
                                 "Failed to mark daemon as dead during shutdown"
@@ -628,8 +629,10 @@ where
                                 }
                             }
                             Err(e) => {
-                                counter!("fusillade_cancellation_poll_errors_total").increment(1);
-                                tracing::warn!(
+                                // Sustained failure means cancelled batches keep spending and
+                                // completed batches never get finalized - error, not warn.
+                                crate::background_error!(
+                                    "cancellation_poll_failed", Error,
                                     error = %e,
                                     "Failed to check batch cancellation status"
                                 );
@@ -690,8 +693,7 @@ where
                                 }
                             }
                             Err(e) => {
-                                counter!("fusillade_purge_errors_total").increment(1);
-                                tracing::error!(error = %e, "Failed to purge orphaned rows");
+                                crate::background_error!("purge_failed", Error, error = %e, "Failed to purge orphaned rows");
                                 break;
                             }
                         }
@@ -716,11 +718,10 @@ where
                         tracing::trace!("Task completed successfully");
                     }
                     Ok(Err(e)) => {
-                        tracing::error!(error = %e, "Task failed");
+                        crate::background_error!("task_failed", Error, error = %e, "Task failed");
                     }
                     Err(join_error) => {
-                        counter!("fusillade_task_panics_total").increment(1);
-                        tracing::error!(error = %join_error, "Task panicked");
+                        crate::background_error!("task_panicked", Critical, error = %join_error, "Task panicked");
                     }
                 }
             }
@@ -1204,7 +1205,7 @@ where
         // Wait for heartbeat task to complete (it will mark daemon as dead)
         tracing::info!("Waiting for heartbeat task to complete");
         if let Err(e) = heartbeat_handle.await {
-            tracing::error!(error = %e, "Heartbeat task panicked");
+            crate::background_error!("heartbeat_task_panicked", Critical, error = %e, "Heartbeat task panicked");
         }
 
         run_result

--- a/src/http.rs
+++ b/src/http.rs
@@ -528,8 +528,12 @@ impl ReqwestHttpClient {
         }
 
         let body = match &self.stream_reassembler {
-            Some(reassemble) => reassemble(&collected)?,
-            None => collected
+            // Only reassemble successful streams. An error response (empty or a
+            // contentless chunk) must not be synthesized into a degenerate
+            // `{"choices":[],"usage":null}` completion — return its raw payload
+            // so the real HTTP status drives retry classification.
+            Some(reassemble) if status < 400 => reassemble(&collected)?,
+            _ => collected
                 .iter()
                 .filter(|e| !e.data.is_empty() && e.data != "[DONE]")
                 .map(|e| e.data.as_str())

--- a/src/http.rs
+++ b/src/http.rs
@@ -1355,6 +1355,78 @@ mod tests {
         assert_eq!(body["usage"]["total_tokens"], 7);
     }
 
+    #[tokio::test]
+    async fn test_streaming_error_status_skips_reassembly() {
+        use axum::{Router, http::StatusCode, routing::post};
+
+        // An error-status SSE response whose chunks, if reassembled, would
+        // synthesize a successful-looking `chat.completion`. The `status < 400`
+        // guard must bypass reassembly and return the raw payload so the real
+        // 5xx drives retry classification (rather than a misleading or
+        // degenerate `{"choices":[],"usage":null}` completion).
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let sse = concat!(
+                    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+                    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n",
+                    "data: [DONE]\n\n",
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [("content-type", "text/event-stream")],
+                    sse,
+                )
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let request = RequestData {
+            id: RequestId::from(uuid::Uuid::new_v4()),
+            batch_id: Some(crate::batch::BatchId::from(uuid::Uuid::new_v4())),
+            template_id: crate::batch::TemplateId::from(uuid::Uuid::new_v4()),
+            custom_id: None,
+            endpoint: format!("http://{}", addr),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            body: r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#.to_string(),
+            model: "gpt-4".to_string(),
+            api_key: "".to_string(),
+            created_by: String::new(),
+            batch_metadata: std::collections::HashMap::new(),
+        };
+
+        // Default client has openai reassembly enabled.
+        let client = ReqwestHttpClient::new(
+            ONE_DAY_DURATION,
+            ONE_DAY_DURATION,
+            ONE_DAY_DURATION,
+            vec!["/v1/chat/completions".to_string()],
+        );
+        let response = client.execute(&request, "").await.unwrap();
+
+        // Real HTTP status preserved, so retry classification sees a 5xx.
+        assert_eq!(response.status, 500);
+
+        // Body is the raw SSE payload, not reassembled: the chunk-level
+        // `chat.completion.chunk` objects survive verbatim, and the raw
+        // multi-chunk body does not parse as one reassembled JSON object.
+        assert!(
+            response.body.contains("chat.completion.chunk"),
+            "error-status body should be raw chunks, got: {}",
+            response.body
+        );
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&response.body).is_err(),
+            "raw multi-chunk body should not parse as a single reassembled object, got: {}",
+            response.body
+        );
+    }
+
     /// Captures every event's `data` field into a shared Vec. Used by
     /// the streaming callback tests below. `StreamEvent` itself is
     /// borrowed from fusillade's per-chunk parse buffer, so the test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! Batching system with PostgreSQL storage and background daemon for processing requests.
 
 pub mod batch;
+pub mod bg_errors;
 pub mod daemon;
 pub mod error;
 pub mod http;

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -6462,14 +6462,10 @@ mod tests {
 
         manager.delete_file(file_id).await.unwrap();
 
-        let err = manager
+        manager
             .populate_batch(batch_id, file_id)
             .await
-            .expect_err("populate_batch should fail after source file deleted");
-        assert!(
-            matches!(err, FusilladeError::ValidationError(_)),
-            "expected ValidationError so the dwctl task is marked Fatal, got: {err:?}"
-        );
+            .expect("populate_batch is a no-op after source file deleted");
     }
 
     #[sqlx::test]

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -2577,14 +2577,16 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
         .map_err(|e| FusilladeError::Other(anyhow!("Failed to fetch batch state: {}", e)))?;
 
         if row.batch_deleted_at.is_some() {
-            return Err(FusilladeError::ValidationError(
-                "batch was deleted before population".to_string(),
-            ));
+            // Deleted before population could run - nothing to populate. The delete
+            // path owns the batch's final state, so this is a clean no-op, not a failure.
+            tracing::debug!(batch_id = %*batch_id, "Batch deleted before population, skipping");
+            return Ok(());
         }
         if row.cancelling_at.is_some() {
-            return Err(FusilladeError::ValidationError(
-                "batch was cancelled before population".to_string(),
-            ));
+            // Cancelled before population could run - nothing to populate. The cancel
+            // path owns the batch's final state, so this is a clean no-op, not a failure.
+            tracing::debug!(batch_id = %*batch_id, "Batch cancelled before population, skipping");
+            return Ok(());
         }
         if row.file_deleted_at.is_some() {
             return Err(FusilladeError::ValidationError(
@@ -2975,7 +2977,9 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                     );
                 }
                 unknown => {
-                    return Err(FusilladeError::Other(anyhow!(
+                    // Invalid client-supplied filter value - a bad request, not a server
+                    // fault. ValidationError so dwctl maps it to 400, not 500 (which pages).
+                    return Err(FusilladeError::ValidationError(format!(
                         "Unknown batch status filter: '{}'. Valid values: in_progress, completed, failed, cancelled, expired",
                         unknown
                     )));

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -6478,14 +6478,10 @@ mod tests {
 
         manager.cancel_batch(batch_id).await.unwrap();
 
-        let err = manager
+        manager
             .populate_batch(batch_id, file_id)
             .await
-            .expect_err("populate_batch should fail after batch cancelled");
-        assert!(
-            matches!(err, FusilladeError::ValidationError(_)),
-            "expected ValidationError, got: {err:?}"
-        );
+            .expect("populate_batch is a no-op after batch cancelled");
     }
 
     #[sqlx::test]
@@ -6494,14 +6490,10 @@ mod tests {
 
         manager.delete_batch(batch_id).await.unwrap();
 
-        let err = manager
+        manager
             .populate_batch(batch_id, file_id)
             .await
-            .expect_err("populate_batch should fail after batch deleted");
-        assert!(
-            matches!(err, FusilladeError::ValidationError(_)),
-            "expected ValidationError, got: {err:?}"
-        );
+            .expect("populate_batch is a no-op after batch deleted");
     }
 
     // =========================================================================


### PR DESCRIPTION
# standardise error logs into having metric emissions

## What

Replaces fusillade's scattered, hand-maintained failure counters with a single
unified metric, `fusillade_background_errors_total{component, reason, severity}`,
emitted together with the log line by a new `background_error!` macro. One call
site produces both the metric and the `tracing` event, so they can never drift.

Also folds in two correctness fixes found while auditing the error paths.

## The unified metric

`background_error!(reason, Severity, ...fields, "message")` emits
`fusillade_background_errors_total` and a matching `tracing` event in one shot.
Fusillade has a single component (`daemon`), so the macro bakes that in and call
sites only pass `reason`. `reason` and `severity` are `&'static str`, so label
cardinality stays bounded.

Severity is a literal tier that drives both the log level and whether it pages:

- `Critical`: logs at `error!`, pages.
- `Error`: logs at `error!`, does not page (dashboard / rate input).
- `Warning`: logs at `warn!`, does not page.

## Removed counters (no dual-emit)

These bespoke counters are deleted; the same signal is now a labelled slice of
the unified metric:

- `fusillade_heartbeat_failures_total` becomes `..._background_errors_total{reason="heartbeat_failed"}`
- `fusillade_task_panics_total` becomes `...{reason="task_panicked"}`
- `fusillade_cancellation_poll_errors_total` becomes `...{reason="cancellation_poll_failed"}`
- `fusillade_purge_errors_total` becomes `...{reason="purge_failed"}`


## Correctness fixes

- `populate_batch` now treats a batch that was cancelled or deleted before
  population as a clean no-op (returns `Ok`) rather than a `ValidationError`. The
  cancel/delete path owns the batch's terminal state, so erroring would make the
  caller mark a cancelled batch as failed. It also avoids an INSERT that could
  FK-violate against templates the purge already removed.
- SSE error responses are no longer reassembled. When an upstream returns an HTTP
  error status with a streamed body, the reassembler is skipped for any error
  status (400 and above) so the raw payload and the real status flow through to
  retry classification, instead of being synthesised into a degenerate completion
  like `{"choices":[],"usage":null}`.
