### PR TITLE
perf: add partial index for the claim query's batchless arms

### DIFF
--- a/migrations/20260610000000_add_pending_group_index.up.sql
+++ b/migrations/20260610000000_add_pending_group_index.up.sql
@@ -12,6 +12,15 @@
 -- the batchless (batch_id IS NULL) per-model scan. Batch enumeration itself
 -- (the loose index scan over distinct batch_ids) uses the existing
 -- idx_requests_pending (model, batch_id).
-CREATE INDEX idx_requests_pending_claim_pull
+--
+-- On large production tables this build takes minutes and (non-concurrently)
+-- holds ACCESS EXCLUSIVE for the duration, which can outlast a startup probe
+-- and crash-loop the deploy. Create it CONCURRENTLY before deploying so the
+-- IF NOT EXISTS below becomes a no-op:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_pending_claim_pull
+--   ON requests (model, batch_id, created_at)
+--   WHERE state = 'pending' AND template_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_requests_pending_claim_pull
     ON requests (model, batch_id, created_at)
     WHERE state = 'pending' AND template_id IS NOT NULL;

--- a/migrations/20260615000000_add_pending_batchless_index.down.sql
+++ b/migrations/20260615000000_add_pending_batchless_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_requests_pending_batchless;

--- a/migrations/20260615000000_add_pending_batchless_index.up.sql
+++ b/migrations/20260615000000_add_pending_batchless_index.up.sql
@@ -1,0 +1,26 @@
+-- Index for the claim query's BATCHLESS (flex/async) arms.
+--
+-- `claim_requests` has two batchless arms (Source A full-capacity and Source B
+-- leaky-bucket) that scan pending rows with `batch_id IS NULL` per model. No
+-- existing index covers `batch_id IS NULL`, so Postgres uses idx_requests_state
+-- (or idx_requests_state_model) and filters `batch_id IS NULL` row-by-row. When
+-- a model has a large BATCHED backlog (e.g. millions of pending rows in a few
+-- big batches), each batchless arm scans the entire pending set to find the
+-- (often zero) batchless rows — measured at ~4s per scan on a 53M-row table,
+-- and the claim runs two such arms per model every cycle.
+--
+-- This partial index contains ONLY batchless pending rows (normally a tiny set),
+-- so both arms become an instant index range scan instead of filtering the
+-- whole pending heap. `(model, created_at)` serves the per-model lookup and the
+-- arms' `ORDER BY created_at` / oldest-first pull.
+--
+-- On large production tables, create this CONCURRENTLY before deploying so the
+-- IF NOT EXISTS statement below becomes a no-op:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_pending_batchless
+--   ON requests (model, created_at)
+--   WHERE state = 'pending' AND batch_id IS NULL AND template_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_pending_batchless
+ON requests (model, created_at)
+WHERE state = 'pending' AND batch_id IS NULL AND template_id IS NOT NULL;

--- a/migrations/20260615000000_add_pending_batchless_index.up.sql
+++ b/migrations/20260615000000_add_pending_batchless_index.up.sql
@@ -2,17 +2,21 @@
 --
 -- `claim_requests` has two batchless arms (Source A full-capacity and Source B
 -- leaky-bucket) that scan pending rows with `batch_id IS NULL` per model. No
--- existing index covers `batch_id IS NULL`, so Postgres uses idx_requests_state
--- (or idx_requests_state_model) and filters `batch_id IS NULL` row-by-row. When
--- a model has a large BATCHED backlog (e.g. millions of pending rows in a few
--- big batches), each batchless arm scans the entire pending set to find the
--- (often zero) batchless rows — measured at ~4s per scan on a 53M-row table,
--- and the claim runs two such arms per model every cycle.
+-- existing index has a `batch_id IS NULL` predicate — the indexes that include
+-- batch_id as a *column* (e.g. idx_requests_pending_claim_pull, idx_requests_
+-- batch_state) still contain every pending row — so Postgres uses
+-- idx_requests_state (or idx_requests_state_model) and filters `batch_id IS NULL`
+-- row-by-row. When a model has a large BATCHED backlog (e.g. millions of pending
+-- rows in a few big batches), each batchless arm scans the entire pending set to
+-- find the (often zero) batchless rows — measured at ~4s per scan on a 53M-row
+-- table, and the claim runs two such arms per model every cycle.
 --
 -- This partial index contains ONLY batchless pending rows (normally a tiny set),
--- so both arms become an instant index range scan instead of filtering the
--- whole pending heap. `(model, created_at)` serves the per-model lookup and the
--- arms' `ORDER BY created_at` / oldest-first pull.
+-- so the per-model lookup returns that subset directly instead of filtering the
+-- whole pending heap. The arms then sort the (tiny) candidate set by a computed
+-- fairness/deadline blend — not index-servable, but trivial at ~0 rows — so the
+-- leading `model` key (isolating the subset) is what matters; `created_at` is a
+-- harmless secondary key.
 --
 -- On large production tables, create this CONCURRENTLY before deploying so the
 -- IF NOT EXISTS statement below becomes a no-op:


### PR DESCRIPTION
## Problem

The claim query's two batchless arms (Source A full-capacity + Source B leaky-bucket) scan pending rows with `batch_id IS NULL` per model. **No index covers that predicate**, so when a model has a large *batched* backlog, Postgres scans the entire pending heap to find the (often zero) batchless rows.

Observed in staging (53.7M-row / 255 GB `requests`, ~298k pending in ~24 batches on one model, 0 batchless):
- A single batchless-arm scan: **~4.0 s** (`Rows Removed by Filter: 183,956` → 0 found).
- `pg_stat_statements` for the claim query: **mean 256 ms, max 48.7 s**.

## Fix

A partial index containing only batchless pending rows (normally a tiny/empty set), so both arms become an instant index range scan:

```sql
CREATE INDEX idx_requests_pending_batchless
ON requests (model, created_at)
WHERE state = 'pending' AND batch_id IS NULL AND template_id IS NOT NULL;
```

Validated on staging: batchless arm went from the 4 s heap scan to a direct index scan (`cost 0.12..39.47`, no Sort).

## Deploy notes

- Follows the established "create CONCURRENTLY pre-deploy → migration is a no-op (`IF NOT EXISTS`)" pattern.
- **Run `ANALYZE requests` after creating the index** — a freshly built partial index isn't chosen by the planner until stats exist (confirmed on staging; before ANALYZE it kept using the old state index).
- Already created CONCURRENTLY on the staging Neon branch; prod needs the same `CREATE INDEX CONCURRENTLY … ; ANALYZE requests;` before this migration deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)