### PR TITLE
perf(db): tighten autovacuum/autoanalyze on requests and batches

### DIFF
--- a/migrations/20260617000000_tune_autovacuum_high_churn_tables.down.sql
+++ b/migrations/20260617000000_tune_autovacuum_high_churn_tables.down.sql
@@ -11,5 +11,7 @@ ALTER TABLE batches RESET (
     autovacuum_vacuum_scale_factor,
     autovacuum_vacuum_threshold,
     autovacuum_analyze_scale_factor,
-    autovacuum_analyze_threshold
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_insert_scale_factor,
+    autovacuum_vacuum_insert_threshold
 );

--- a/migrations/20260617000000_tune_autovacuum_high_churn_tables.down.sql
+++ b/migrations/20260617000000_tune_autovacuum_high_churn_tables.down.sql
@@ -1,0 +1,15 @@
+ALTER TABLE requests RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_scale_factor,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_insert_scale_factor,
+    autovacuum_vacuum_insert_threshold
+);
+
+ALTER TABLE batches RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_scale_factor,
+    autovacuum_analyze_threshold
+);

--- a/migrations/20260617000000_tune_autovacuum_high_churn_tables.up.sql
+++ b/migrations/20260617000000_tune_autovacuum_high_churn_tables.up.sql
@@ -1,0 +1,36 @@
+-- Tighten autovacuum / autoanalyze for the high-churn claim tables.
+--
+-- `requests` and `batches` change constantly: every request moves
+-- pending -> claimed -> processing -> terminal, and batches are created and
+-- completed continuously. Postgres's default autovacuum/autoanalyze scale
+-- factors (0.2 / 0.1) are a *fraction of the whole table*, so the larger these
+-- tables get, the more dead/changed rows must accumulate before maintenance
+-- fires. Two failure modes follow on these specific tables:
+--
+--   * planner statistics go stale, so the claim query mis-estimates row counts
+--     and stops choosing its purpose-built partial indexes (idx_requests_pending*),
+--     falling back to a broad state-only index scan; and
+--   * dead tuples accumulate, which bloats indexes and forces the claim's
+--     index-only scans to fall back to heap fetches.
+--
+-- Switch both tables to absolute thresholds (scale_factor = 0, threshold = N)
+-- so autovacuum and autoanalyze fire after a fixed number of changes regardless
+-- of how large the table grows, keeping statistics fresh and dead-tuple bloat
+-- bounded. This is a metadata-only change and takes effect on the next
+-- autovacuum cycle.
+
+ALTER TABLE requests SET (
+    autovacuum_vacuum_scale_factor        = 0.0,
+    autovacuum_vacuum_threshold           = 50000,
+    autovacuum_analyze_scale_factor       = 0.0,
+    autovacuum_analyze_threshold          = 50000,
+    autovacuum_vacuum_insert_scale_factor = 0.0,
+    autovacuum_vacuum_insert_threshold    = 50000
+);
+
+ALTER TABLE batches SET (
+    autovacuum_vacuum_scale_factor  = 0.0,
+    autovacuum_vacuum_threshold     = 10000,
+    autovacuum_analyze_scale_factor = 0.0,
+    autovacuum_analyze_threshold    = 10000
+);

--- a/migrations/20260617000000_tune_autovacuum_high_churn_tables.up.sql
+++ b/migrations/20260617000000_tune_autovacuum_high_churn_tables.up.sql
@@ -16,8 +16,18 @@
 -- Switch both tables to absolute thresholds (scale_factor = 0, threshold = N)
 -- so autovacuum and autoanalyze fire after a fixed number of changes regardless
 -- of how large the table grows, keeping statistics fresh and dead-tuple bloat
--- bounded. This is a metadata-only change and takes effect on the next
--- autovacuum cycle.
+-- bounded. We pin the insert-triggered thresholds (autovacuum_vacuum_insert_*)
+-- on both tables as well: both are insert-heavy (requests are inserted in bulk
+-- at batch creation; batches are created continuously), and insert-triggered
+-- vacuums are what freeze tuples and keep the visibility map current so the
+-- claim's index-only scans don't fall back to heap fetches.
+--
+-- `requests` uses a higher absolute threshold (50k) than `batches` (10k): it is
+-- the far larger, higher-volume table (bulk request inserts plus per-claim state
+-- churn), so a higher bound avoids vacuuming it excessively; the smaller
+-- `batches` table gets a tighter bound to keep its statistics fresh.
+--
+-- Metadata-only change; takes effect on the next autovacuum cycle.
 
 ALTER TABLE requests SET (
     autovacuum_vacuum_scale_factor        = 0.0,
@@ -29,8 +39,10 @@ ALTER TABLE requests SET (
 );
 
 ALTER TABLE batches SET (
-    autovacuum_vacuum_scale_factor  = 0.0,
-    autovacuum_vacuum_threshold     = 10000,
-    autovacuum_analyze_scale_factor = 0.0,
-    autovacuum_analyze_threshold    = 10000
+    autovacuum_vacuum_scale_factor        = 0.0,
+    autovacuum_vacuum_threshold           = 10000,
+    autovacuum_analyze_scale_factor       = 0.0,
+    autovacuum_analyze_threshold          = 10000,
+    autovacuum_vacuum_insert_scale_factor = 0.0,
+    autovacuum_vacuum_insert_threshold    = 10000
 );


### PR DESCRIPTION
## What
Adds migration `20260617000000_tune_autovacuum_high_churn_tables`, setting per-table autovacuum/autoanalyze parameters on `requests` and `batches`.

## Why
Both tables are high-churn — every request transitions `pending → claimed → processing → terminal`, and batches are created and completed continuously. Postgres's default autovacuum/autoanalyze **scale factors** (`0.2` / `0.1`) are a fraction of the *whole table*, so as these tables grow, an ever-larger number of dead/changed rows must accumulate before maintenance runs. Two consequences once they're large:

- **Stale planner statistics** → the batch-claim query mis-estimates row counts and stops choosing its purpose-built partial indexes (`idx_requests_pending*`), falling back to a broad state-only index scan.
- **Dead-tuple bloat** → bloats indexes and forces the claim's index-only scans to fall back to heap fetches.

## Change
Switch both tables to **absolute thresholds** (`scale_factor = 0`, `threshold = N`) so autovacuum/autoanalyze fire after a fixed number of changes regardless of table size — keeping statistics fresh and bloat bounded. `requests` gets a higher threshold (50k) than `batches` (10k) to match their relative change volume.

Metadata-only change; reversible (`down` `RESET`s the params). Takes effect on the next autovacuum cycle — no rewrite, no locks beyond a brief catalog update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)