### PR TITLE
fix!: prevent retry from resurrecting requests under finalized batches

### DIFF
--- a/.sqlx/query-fc35737bc90e230160f0bee95cb3b7ad2bc16effd3e2e910957a59e0f7a2adc6.json
+++ b/.sqlx/query-fc35737bc90e230160f0bee95cb3b7ad2bc16effd3e2e910957a59e0f7a2adc6.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE requests SET\n                state = 'pending',\n                retry_attempt = $3,\n                not_before = $4,\n                daemon_id = NULL,\n                claimed_at = NULL,\n                started_at = NULL\n            WHERE id = $1\n              AND state = 'processing'\n              AND daemon_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int4",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fc35737bc90e230160f0bee95cb3b7ad2bc16effd3e2e910957a59e0f7a2adc6"
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1163,6 +1163,10 @@ where
                         // single capture suffices for downstream metrics.
                         let retry_attempt_at_completion = request.state.retry_attempt;
                         let batch_expires_at = request.state.batch_expires_at;
+                        // Capture the owning daemon before the request moves into
+                        // the processor — the fenced retry reschedule needs it to
+                        // prove this worker still holds the in-flight claim.
+                        let owning_daemon_id = request.state.daemon_id;
 
                         // Build the cancellation future the daemon owns. The
                         // processor observes this without needing to know about
@@ -1239,28 +1243,60 @@ where
                                     // Attempt to retry
                                     match failed.can_retry(retry_attempt, retry_config) {
                                         Ok(pending) => {
-                                            // Can retry - persist as Pending
-                                            if let Err(e) = storage.persist(&pending).await {
-                                                tracing::error!(
-                                                    request_id = %request_id,
-                                                    batch_id = ?batch_id,
-                                                    retry_attempt = pending.state.retry_attempt,
-                                                    error = %e,
-                                                    "Failed to persist retry — request orphaned in processing state"
-                                                );
-                                                return Err(e);
+                                            // Fenced retry: only re-pend if we still own the
+                                            // in-flight (processing) row. If another writer has
+                                            // already terminalized it — and a finalizer may have
+                                            // sealed the parent batch as a result — flipping it
+                                            // back to pending here would orphan it under a
+                                            // completed batch (the count/claim mismatch then
+                                            // surfaces it as undrainable queue depth).
+                                            match storage
+                                                .reschedule_for_retry(
+                                                    request_id,
+                                                    owning_daemon_id,
+                                                    pending.state.retry_attempt,
+                                                    pending.state.not_before,
+                                                )
+                                                .await
+                                            {
+                                                Ok(true) => {
+                                                    counter!(
+                                                        "fusillade_requests_retried_total",
+                                                        "model" => model_clone.clone(),
+                                                        "attempt" => (retry_attempt + 1).to_string()
+                                                    ).increment(1);
+                                                    tracing::info!(
+                                                        request_id = %request_id,
+                                                        batch_id = ?batch_id,
+                                                        retry_attempt = retry_attempt + 1,
+                                                        "request.retry_persisted"
+                                                    );
+                                                }
+                                                Ok(false) => {
+                                                    // Lost the race: the row is no longer this
+                                                    // worker's processing claim. Do NOT resurrect.
+                                                    counter!(
+                                                        "fusillade_requests_retry_lost_ownership_total",
+                                                        "model" => model_clone.clone()
+                                                    ).increment(1);
+                                                    tracing::warn!(
+                                                        request_id = %request_id,
+                                                        batch_id = ?batch_id,
+                                                        retry_attempt = retry_attempt + 1,
+                                                        "request.retry_skipped_lost_ownership"
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    tracing::error!(
+                                                        request_id = %request_id,
+                                                        batch_id = ?batch_id,
+                                                        retry_attempt = pending.state.retry_attempt,
+                                                        error = %e,
+                                                        "Failed to reschedule retry"
+                                                    );
+                                                    return Err(e);
+                                                }
                                             }
-                                            counter!(
-                                                "fusillade_requests_retried_total",
-                                                "model" => model_clone.clone(),
-                                                "attempt" => (retry_attempt + 1).to_string()
-                                            ).increment(1);
-                                            tracing::info!(
-                                                request_id = %request_id,
-                                                batch_id = ?batch_id,
-                                                retry_attempt = retry_attempt + 1,
-                                                "request.retry_persisted"
-                                            );
                                         }
                                         Err(failed) => {
                                             // No retries left - persist as Failed (terminal)

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -531,6 +531,32 @@ pub trait Storage: Send + Sync {
     where
         AnyRequest: From<Request<T>>;
 
+    /// Reschedule an in-flight request back to `pending` for an automatic retry,
+    /// fenced on the worker that currently owns it.
+    ///
+    /// This is the daemon's per-attempt retry path. Unlike [`Storage::persist`]
+    /// (which matches on `id` only, so the manual retry path can intentionally
+    /// resurrect a `failed` row), this transition is guarded by
+    /// `state = 'processing' AND daemon_id = <owner>`: it applies ONLY if the row
+    /// is still the in-flight claim held by `daemon_id`.
+    ///
+    /// The guard prevents a finalize-then-resurrect race: if another writer (a
+    /// zombie/duplicate worker, or a stale-claim reclaim) has already moved the
+    /// row to a terminal state — and a finalizer has sealed the parent batch as a
+    /// result — a late retry from this worker must NOT flip it back to `pending`,
+    /// orphaning it under a completed batch.
+    ///
+    /// Returns `true` if the row was rescheduled, `false` if the worker no longer
+    /// owns it (lost the race). A `false` result is normal under contention and
+    /// should be logged, not treated as an error.
+    async fn reschedule_for_retry(
+        &self,
+        request_id: RequestId,
+        owner: DaemonId,
+        retry_attempt: u32,
+        not_before: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<bool>;
+
     /// List individual requests across batches with filtering and pagination.
     ///
     /// Supports filtering by creator, completion window, status, model(s),

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -951,7 +951,18 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 FROM active_request_counts arc
                 JOIN batches b ON arc.batch_id = b.id
                 CROSS JOIN windows w
+                -- Only count rows the daemon can actually claim. This MUST stay in
+                -- sync with the batch eligibility filter in `claim_requests`
+                -- (`ranked_batches`): excluding only `cancelling_at` here while the
+                -- claim path also excludes terminal batches lets a `pending` row
+                -- stranded under an already-completed batch (e.g. a retry that
+                -- raced batch finalization) be reported as claimable forever while
+                -- never actually being claimed.
                 WHERE b.cancelling_at IS NULL
+                  AND b.deleted_at IS NULL
+                  AND b.completed_at IS NULL
+                  AND b.failed_at IS NULL
+                  AND b.cancelled_at IS NULL
                 -- Row-level upper bound: a row that expires after every window's
                 -- end can't contribute to any window's COUNT FILTER, so prune it
                 -- here. Without this, the join reads every active+templated
@@ -1931,6 +1942,48 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             "Failed to persist request state after {} attempts",
             MAX_ATTEMPTS
         )))
+    }
+
+    async fn reschedule_for_retry(
+        &self,
+        request_id: RequestId,
+        owner: DaemonId,
+        retry_attempt: u32,
+        not_before: Option<DateTime<Utc>>,
+    ) -> Result<bool> {
+        // Fenced retry: only re-pend the row if it is still the in-flight claim
+        // held by `owner`. The `state = 'processing' AND daemon_id = $2` guard is
+        // what distinguishes this from the manual retry path (which uses persist()
+        // to intentionally move a terminal `failed` row back to pending). If
+        // another writer has already terminalized this row — and a finalizer has
+        // sealed the parent batch off the back of that — a late retry here would
+        // otherwise orphan a `pending` row under a completed batch.
+        let rows_affected = sqlx::query!(
+            r#"
+            UPDATE requests SET
+                state = 'pending',
+                retry_attempt = $3,
+                not_before = $4,
+                daemon_id = NULL,
+                claimed_at = NULL,
+                started_at = NULL
+            WHERE id = $1
+              AND state = 'processing'
+              AND daemon_id = $2
+            "#,
+            *request_id as Uuid,
+            *owner as Uuid,
+            retry_attempt as i32,
+            not_before,
+        )
+        .execute(self.pools.write())
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!("Failed to reschedule request for retry: {}", e))
+        })?
+        .rows_affected();
+
+        Ok(rows_affected > 0)
     }
 
     #[tracing::instrument(skip(self, ids), fields(count = ids.len()))]
@@ -7150,6 +7203,258 @@ mod tests {
         assert_eq!(status.total_requests, 5);
         assert_eq!(status.pending_requests, 0);
         assert_eq!(status.in_progress_requests, 5); // All claimed
+    }
+
+    /// Helper: stand up a manager with a single-request batch, claim it for
+    /// `daemon_id`, and move the row into `processing` (the precondition the
+    /// daemon's fenced retry reschedule runs from).
+    async fn setup_processing_request(
+        pool: &sqlx::PgPool,
+        daemon_id: DaemonId,
+    ) -> (
+        PostgresRequestManager<TestDbPools, MockHttpClient>,
+        RequestId,
+    ) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        );
+
+        let file_id = manager
+            .create_file(
+                "retry-fence-test".to_string(),
+                None,
+                vec![RequestTemplateInput {
+                    custom_id: None,
+                    endpoint: "https://api.example.com".to_string(),
+                    method: "POST".to_string(),
+                    path: "/test".to_string(),
+                    body: r#"{"n":0}"#.to_string(),
+                    model: "test".to_string(),
+                    api_key: "key".to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+
+        manager
+            .create_batch(crate::batch::BatchInput {
+                file_id,
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: "24h".to_string(),
+                metadata: None,
+                created_by: None,
+                api_key_id: None,
+                api_key: None,
+                total_requests: None,
+            })
+            .await
+            .unwrap();
+
+        let capacity = HashMap::from([("test".to_string(), 10)]);
+        let claimed = manager
+            .claim_requests(1, daemon_id, &capacity, &HashMap::new(), &HashSet::new())
+            .await
+            .expect("claim failed");
+        assert_eq!(claimed.len(), 1);
+        let request_id = claimed[0].data.id;
+
+        // Advance claimed -> processing, keeping the same owner. This mirrors the
+        // daemon's claimed->processing transition without spawning HTTP work.
+        sqlx::query("UPDATE requests SET state = 'processing', started_at = NOW() WHERE id = $1")
+            .bind(*request_id)
+            .execute(pool)
+            .await
+            .unwrap();
+
+        (manager, request_id)
+    }
+
+    async fn read_request_row(pool: &sqlx::PgPool, request_id: RequestId) -> (String, i32) {
+        sqlx::query_as::<_, (String, i32)>(
+            "SELECT state, retry_attempt FROM requests WHERE id = $1",
+        )
+        .bind(*request_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Happy path: the owning daemon reschedules its own in-flight request.
+    #[sqlx::test]
+    async fn test_reschedule_for_retry_owner_succeeds(pool: sqlx::PgPool) {
+        let daemon_id = DaemonId::from(Uuid::new_v4());
+        let (manager, request_id) = setup_processing_request(&pool, daemon_id).await;
+
+        let not_before = chrono::Utc::now() + chrono::Duration::seconds(30);
+        let rescheduled = manager
+            .reschedule_for_retry(request_id, daemon_id, 1, Some(not_before))
+            .await
+            .unwrap();
+
+        assert!(
+            rescheduled,
+            "owner should reschedule its own processing row"
+        );
+        let (state, retry) = read_request_row(&pool, request_id).await;
+        assert_eq!(state, "pending");
+        assert_eq!(retry, 1);
+    }
+
+    /// Regression: a late retry must NOT resurrect a row another writer has
+    /// already terminalized. This is the finalize-then-resurrect race that
+    /// stranded `pending` requests under completed batches.
+    #[sqlx::test]
+    async fn test_reschedule_for_retry_does_not_resurrect_terminal(pool: sqlx::PgPool) {
+        let daemon_id = DaemonId::from(Uuid::new_v4());
+        let (manager, request_id) = setup_processing_request(&pool, daemon_id).await;
+
+        // Another writer (zombie/duplicate worker) terminalizes the row first.
+        sqlx::query(
+            "UPDATE requests SET state = 'failed', failed_at = NOW(), error = 'terminal', daemon_id = NULL WHERE id = $1",
+        )
+        .bind(*request_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let not_before = chrono::Utc::now() + chrono::Duration::seconds(30);
+        let rescheduled = manager
+            .reschedule_for_retry(request_id, daemon_id, 1, Some(not_before))
+            .await
+            .unwrap();
+
+        assert!(!rescheduled, "must not reschedule a terminalized row");
+        let (state, _) = read_request_row(&pool, request_id).await;
+        assert_eq!(
+            state, "failed",
+            "row must stay terminal, not resurrect to pending"
+        );
+    }
+
+    /// A daemon that no longer owns the row (it was reclaimed and re-claimed
+    /// elsewhere) must not be able to reschedule it.
+    #[sqlx::test]
+    async fn test_reschedule_for_retry_wrong_owner_skips(pool: sqlx::PgPool) {
+        let owner = DaemonId::from(Uuid::new_v4());
+        let (manager, request_id) = setup_processing_request(&pool, owner).await;
+
+        let other = DaemonId::from(Uuid::new_v4());
+        let rescheduled = manager
+            .reschedule_for_retry(request_id, other, 1, None)
+            .await
+            .unwrap();
+
+        assert!(!rescheduled, "non-owning daemon must not reschedule");
+        let (state, _) = read_request_row(&pool, request_id).await;
+        assert_eq!(
+            state, "processing",
+            "row must remain the owner's in-flight claim"
+        );
+    }
+
+    /// Regression: pending requests stranded under a terminal (completed) batch
+    /// must not be reported as claimable. `get_pending_request_counts_*` has to
+    /// exclude the same terminal batches `claim_requests` excludes, otherwise the
+    /// count reports undrainable phantom queue depth forever.
+    #[sqlx::test]
+    async fn test_pending_counts_exclude_terminal_batches(pool: sqlx::PgPool) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        );
+
+        let file_id = manager
+            .create_file(
+                "terminal-count-test".to_string(),
+                None,
+                vec![RequestTemplateInput {
+                    custom_id: None,
+                    endpoint: "https://api.example.com".to_string(),
+                    method: "POST".to_string(),
+                    path: "/test".to_string(),
+                    body: r#"{"n":0}"#.to_string(),
+                    model: "test".to_string(),
+                    api_key: "key".to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let batch = manager
+            .create_batch(crate::batch::BatchInput {
+                file_id,
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: "24h".to_string(),
+                metadata: None,
+                created_by: None,
+                api_key_id: None,
+                api_key: None,
+                total_requests: None,
+            })
+            .await
+            .unwrap();
+
+        let now = chrono::Utc::now();
+        sqlx::query!(
+            "UPDATE batches SET expires_at = $1 WHERE id = $2",
+            now + chrono::Duration::minutes(30),
+            *batch.id as Uuid
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let windows = vec![("1h".to_string(), None, 3600)];
+        let states = vec!["pending".to_string()];
+        let model_filter: Vec<String> = vec![];
+
+        // Control: an active batch's pending request is counted.
+        let before = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(*before.get("test").unwrap().get("1h").unwrap(), 1);
+
+        // Strand the pending request: the batch gets finalized as completed
+        // while a child is still pending (the finalize-then-resurrect race).
+        sqlx::query!(
+            "UPDATE batches SET finalizing_at = $1, completed_at = $1 WHERE id = $2",
+            now,
+            *batch.id as Uuid
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The orphan must no longer be counted as claimable.
+        let after = manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Any,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            after
+                .get("test")
+                .and_then(|m| m.get("1h"))
+                .copied()
+                .unwrap_or(0),
+            0,
+            "pending request under a completed batch must not be counted"
+        );
     }
 
     #[sqlx::test]


### PR DESCRIPTION
## Problem

`get_pending_request_counts_by_model_and_window` reported claimable requests (observed: 6 for `lightonai/LightOnOCR-2-1B-bbox-soup`) that `claim_requests` could never drain — phantom, undrainable queue depth. In prod this stranded `pending` rows under already-completed batches.

## Root cause — finalize-then-resurrect race

A request that fails and is auto-retried is persisted `processing -> pending` via the generic `persist`, which matches `WHERE id = $1` only (no state guard). If a zombie/duplicate worker (e.g. a stale-claim reclaim while the original worker is still alive) has already terminalized the row — and `poll_completed_batches` sealed the parent batch as `completed` off the back of that — the late retry flips the row back to `pending` **under a completed batch**.

- `claim_requests` (`ranked_batches`) excludes completed/failed/cancelled/deleted batches, so the orphan can never be claimed.
- `get_pending_request_counts_by_model_and_window` (`batch_counts`) excluded only `cancelling_at`, so it counted the orphan as claimable forever.

(In the prod incident, `notification_sent_at == completed_at` to the microsecond confirmed `poll_completed_batches` was the finalizer, and each orphan's `not_before` was ~8s *after* `completed_at` — i.e. resurrected after the batch was sealed.)

## Changes

- **Fence the auto-retry.** New `Storage::reschedule_for_retry`, guarded by `state = 'processing' AND daemon_id = <owner>`, used by the daemon's per-attempt retry instead of the unguarded `persist`. A worker that no longer owns the in-flight row no-ops (`request.retry_skipped_lost_ownership` + `fusillade_requests_retry_lost_ownership_total`) instead of resurrecting it. The generic `persist` is untouched, so the manual retry path's intentional `failed -> pending` still works.
- **Align count with claim.** `get_pending_request_counts_by_model_and_window`'s `batch_counts` now excludes completed/failed/cancelled/deleted batches, matching `claim_requests` batch eligibility exactly.
- **Regression tests:** owner-succeeds, does-not-resurrect-terminal, wrong-owner-skips, pending-counts-exclude-terminal-batches.

## Scope / non-goals

- This **prevents new orphans and stops counting old ones**; it does **not** heal pre-existing stranded rows. Those are cleaned up by a one-time prod data patch (cancelling the orphans). A self-healing reaper was considered but left out of this PR.
- No changes to the claim or finalization hot paths. The retry path swaps one single-row `UPDATE` for another (slightly more selective); the count query adds 4 `IS NULL` predicates on already-joined batch rows.

## Testing

- `just lint` clean (fmt, clippy `-D warnings`, `sqlx prepare --check`).
- Full suite green. `test_deadline_aware_retry_stops_before_deadline` is a pre-existing timing-sensitive test (its own comment allows a 7–9 range); it flaked once under the saturated parallel run and passes 3/3 in isolation — retry timing is unchanged by this PR.

## Breaking change

`Storage` gains a required `reschedule_for_retry` method; external implementors must implement it. Marked `fix!:` for a major bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)