### PR TITLE
feat: add leaving model_filters state + current_filter_states read

### DIFF
--- a/.sqlx/query-aadcd206c1c6b82a373bc6895c8a9a47c14e9feea93e1a62e1930ef045391181.json
+++ b/.sqlx/query-aadcd206c1c6b82a373bc6895c8a9a47c14e9feea93e1a62e1930ef045391181.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT DISTINCT ON (model)\n                model, state, created_at\n            FROM model_filters\n            ORDER BY model, created_at DESC, id DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "model",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aadcd206c1c6b82a373bc6895c8a9a47c14e9feea93e1a62e1930ef045391181"
+}

--- a/migrations/20260625000000_add_leaving_model_filter_state.down.sql
+++ b/migrations/20260625000000_add_leaving_model_filter_state.down.sql
@@ -1,0 +1,10 @@
+-- Reverse the `leaving` state. `leaving` is a transient draining state on the way
+-- to `absent`; collapse any such events to `absent` (which preserves the not-live
+-- semantics of the latest event per model) before narrowing the CHECK constraint
+-- back to the original three states. Without this, narrowing would fail if any
+-- `leaving` rows exist.
+UPDATE model_filters SET state = 'absent' WHERE state = 'leaving';
+ALTER TABLE model_filters DROP CONSTRAINT model_filters_state_check;
+ALTER TABLE model_filters
+    ADD CONSTRAINT model_filters_state_check
+    CHECK (state IN ('live', 'coming', 'absent'));

--- a/migrations/20260625000000_add_leaving_model_filter_state.up.sql
+++ b/migrations/20260625000000_add_leaving_model_filter_state.up.sql
@@ -1,0 +1,17 @@
+-- Add the `leaving` state to model_filters (graceful scale-down / drain).
+--
+-- `leaving` marks a model the controller has decided to scale to zero but whose
+-- workers are still up finishing in-flight requests (so it is still listed in the
+-- gateway `/v1/models`). It sits between `live` and `absent` in the teardown
+-- lifecycle:
+--     live -> leaving (draining, still serving) -> absent (workers gone)
+--
+-- The claim gate treats `leaving` as NOT-LIVE, identical to `coming`/`absent`:
+-- the gate only claims at full capacity when `state = 'live'` (or a model has no
+-- events at all), so any non-`live` value already falls onto the leaky-bucket +
+-- deadline-ramp path with NO query change. This migration only widens the CHECK
+-- constraint to admit the new value.
+ALTER TABLE model_filters DROP CONSTRAINT model_filters_state_check;
+ALTER TABLE model_filters
+    ADD CONSTRAINT model_filters_state_check
+    CHECK (state IN ('live', 'coming', 'leaving', 'absent'));

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -51,9 +51,12 @@ pub enum ModelFilterState {
     /// "gone", but treated identically to `Coming`/`Absent` by the claim gate
     /// (not-live → no new full-capacity claims).
     Leaving,
-    /// Explicit tombstone: the controller is no longer deploying this model. Appended
-    /// (instead of deleting rows) to retract a model from the log. Treated
-    /// identically to "no events" by the claim gate.
+    /// Explicit tombstone: the controller is no longer deploying this model.
+    /// Appended (instead of deleting rows) to retract a model from the log. Treated
+    /// by the claim gate as NOT-LIVE — the same leaky-bucket + deadline-ramp path as
+    /// `Coming`/`Leaving`. NOTE: this is *not* the same as a model with **no events
+    /// at all**: the gate claims a no-events model at full capacity (it is unmanaged
+    /// — `mf.state IS NULL`), whereas an `Absent` model is explicitly held not-live.
     Absent,
 }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -44,6 +44,13 @@ pub enum ModelFilterState {
     /// Internal infrastructure will serve this model soon; `expected_ready_at`
     /// carries the ETA.
     Coming,
+    /// The controller is draining this model: it has decided to scale the model to
+    /// zero, but the workers are still up finishing their in-flight requests (so it
+    /// stays listed in the gateway's `/v1/models`). Distinguished from `Absent` so
+    /// observers and the controller can tell "scaling down, still serving" from
+    /// "gone", but treated identically to `Coming`/`Absent` by the claim gate
+    /// (not-live → no new full-capacity claims).
+    Leaving,
     /// Explicit tombstone: the controller is no longer deploying this model. Appended
     /// (instead of deleting rows) to retract a model from the log. Treated
     /// identically to "no events" by the claim gate.
@@ -56,6 +63,7 @@ impl ModelFilterState {
         match self {
             ModelFilterState::Live => "live",
             ModelFilterState::Coming => "coming",
+            ModelFilterState::Leaving => "leaving",
             ModelFilterState::Absent => "absent",
         }
     }
@@ -65,6 +73,7 @@ impl ModelFilterState {
         match s {
             "live" => Some(ModelFilterState::Live),
             "coming" => Some(ModelFilterState::Coming),
+            "leaving" => Some(ModelFilterState::Leaving),
             "absent" => Some(ModelFilterState::Absent),
             _ => None,
         }
@@ -520,6 +529,20 @@ pub trait Storage: Send + Sync {
     /// excluding models whose latest event is an `Absent` tombstone
     /// (observability / tests).
     async fn list_model_filters(&self) -> Result<Vec<ModelFilter>>;
+
+    /// The CURRENT state of every model **and when that state began**: the latest
+    /// event per model as `(state, since)`, where `since` is that event's
+    /// `created_at`. Includes `Absent` (a model's latest event may be a tombstone);
+    /// the caller decides what to do with each state.
+    ///
+    /// This is the controller's read for time-based decisions off the log — a
+    /// `Live` model's `since` is when it went live (minimum-lifetime / anti-thrash),
+    /// a `Coming` model's `since` is when it started launching (a stuck-`coming`
+    /// watchdog). The timestamp comes from the persisted log, not in-memory state,
+    /// so it survives controller restarts.
+    async fn current_filter_states(
+        &self,
+    ) -> Result<std::collections::HashMap<String, (ModelFilterState, chrono::DateTime<chrono::Utc>)>>;
 
     /// Update an existing request's state in storage.
     ///

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -1709,6 +1709,40 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             .collect()
     }
 
+    async fn current_filter_states(
+        &self,
+    ) -> Result<std::collections::HashMap<String, (ModelFilterState, DateTime<Utc>)>> {
+        // Latest event per model = its current state and when that state began.
+        // No state filter: the caller keys on Live/Coming and ignores the rest.
+        // (created_at is NOT NULL; the index on (model, created_at DESC, id DESC)
+        // makes DISTINCT ON deterministic and cheap.)
+        let rows = sqlx::query!(
+            r#"
+            SELECT DISTINCT ON (model)
+                model, state, created_at
+            FROM model_filters
+            ORDER BY model, created_at DESC, id DESC
+            "#
+        )
+        .fetch_all(self.pools.read())
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to read current model_filters states: {}",
+                e
+            ))
+        })?;
+
+        rows.into_iter()
+            .map(|row| {
+                let state = ModelFilterState::parse_state(&row.state).ok_or_else(|| {
+                    FusilladeError::Other(anyhow!("Unknown model_filters.state: {}", row.state))
+                })?;
+                Ok((row.model, (state, row.created_at)))
+            })
+            .collect()
+    }
+
     async fn persist<T: RequestState + Clone>(
         &self,
         request: &Request<T>,
@@ -12588,6 +12622,140 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(total, 5, "append-only: every event is retained in the log");
+    }
+
+    #[test]
+    fn test_model_filter_state_roundtrip() {
+        for s in [
+            ModelFilterState::Live,
+            ModelFilterState::Coming,
+            ModelFilterState::Leaving,
+            ModelFilterState::Absent,
+        ] {
+            assert_eq!(
+                ModelFilterState::parse_state(s.as_str()),
+                Some(s),
+                "{s:?} must round-trip through as_str/parse_state"
+            );
+        }
+        assert_eq!(ModelFilterState::Leaving.as_str(), "leaving");
+        assert_eq!(ModelFilterState::parse_state("nonsense"), None);
+    }
+
+    #[sqlx::test]
+    async fn test_current_filter_states_and_leaving(pool: sqlx::PgPool) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        );
+
+        manager
+            .append_model_filter_events(&[
+                ModelFilter {
+                    model: "m-drain".to_string(),
+                    state: ModelFilterState::Live,
+                    expected_ready_at: None,
+                },
+                ModelFilter {
+                    model: "m-coming".to_string(),
+                    state: ModelFilterState::Coming,
+                    expected_ready_at: None,
+                },
+                ModelFilter {
+                    model: "m-gone".to_string(),
+                    state: ModelFilterState::Absent,
+                    expected_ready_at: None,
+                },
+            ])
+            .await
+            .unwrap();
+        // m-drain transitions live -> leaving (decided to scale down, still draining).
+        manager
+            .append_model_filter_event(&ModelFilter {
+                model: "m-drain".to_string(),
+                state: ModelFilterState::Leaving,
+                expected_ready_at: None,
+            })
+            .await
+            .unwrap();
+
+        // list_model_filters excludes only `absent`; `leaving` is a current state.
+        let listed = manager.list_model_filters().await.unwrap();
+        let drain = listed.iter().find(|m| m.model == "m-drain").unwrap();
+        assert_eq!(
+            drain.state,
+            ModelFilterState::Leaving,
+            "leaving round-trips through the append-only log"
+        );
+        assert!(
+            listed.iter().all(|m| m.model != "m-gone"),
+            "absent tombstone is excluded from list_model_filters"
+        );
+
+        // current_filter_states returns (state, since) per model, INCLUDING absent.
+        let states = manager.current_filter_states().await.unwrap();
+        assert_eq!(
+            states.get("m-drain").map(|(s, _)| *s),
+            Some(ModelFilterState::Leaving)
+        );
+        assert_eq!(
+            states.get("m-coming").map(|(s, _)| *s),
+            Some(ModelFilterState::Coming)
+        );
+        assert_eq!(
+            states.get("m-gone").map(|(s, _)| *s),
+            Some(ModelFilterState::Absent),
+            "current_filter_states keeps the latest event even when it is a tombstone"
+        );
+
+        // `since` is the latest event's created_at (the leaving event, ~now).
+        let (_, drain_since) = states["m-drain"];
+        let now = Utc::now();
+        assert!(
+            drain_since <= now && now - drain_since < chrono::Duration::minutes(1),
+            "since reflects the recent leaving-event timestamp"
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_leaving_treated_as_not_live(pool: sqlx::PgPool) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        )
+        .with_config(filter_test_config());
+
+        // Two requests, same user, far deadline (not within ramp). A `leaving` model
+        // must take the not-live leaky-bucket path (≤1 leaked per cycle), exactly
+        // like `coming`/`absent` — proving the claim gate's `state = 'live'`
+        // predicate treats `leaving` as not-live with no special-casing.
+        let expires_at = Utc::now() + chrono::Duration::hours(12);
+        setup_filter_request(&manager, &pool, "u", "drain-model", expires_at).await;
+        setup_filter_request(&manager, &pool, "u", "drain-model", expires_at).await;
+        manager
+            .append_model_filter_event(&ModelFilter {
+                model: "drain-model".to_string(),
+                state: ModelFilterState::Leaving,
+                expected_ready_at: None,
+            })
+            .await
+            .unwrap();
+
+        let daemon_id = DaemonId::from(Uuid::new_v4());
+        let capacity = HashMap::from([("drain-model".to_string(), 5)]);
+        let claimed = manager
+            .claim_requests(10, daemon_id, &capacity, &HashMap::new(), &HashSet::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            claimed.len(),
+            1,
+            "a leaving model is not-live: leaky-bucket trickles ≤1, not full capacity"
+        );
+        assert!(
+            claimed[0].state.leak.is_some(),
+            "the leaving model's claim is leaked (not-live path)"
+        );
     }
 
     #[sqlx::test]


### PR DESCRIPTION
## What

Two additive changes to `model_filters`, both for graceful, drain-gated model scale-down driven by the controller:

1. **New `leaving` state** — between `live` and `absent` in a model's teardown lifecycle:
   ```
   live -> leaving (decided to scale down; workers still up & draining) -> absent (workers gone)
   ```
   It marks a model the controller has decided to scale to zero but whose workers are still serving in-flight requests (still listed in the gateway `/v1/models`), distinguished from `absent` ("gone").

2. **New `current_filter_states()` read** — returns the latest event per model as `(state, since = created_at)`, so the controller can make time-based decisions from the persisted log (a minimum model lifetime, a stuck-`coming` watchdog) that survive controller restarts.

## Claim gate: no query change

The gate claims at full capacity only when `state = 'live'` (or a model has no events). `leaving` is not `'live'`, so it falls onto the existing not-live (leaky-bucket + deadline-ramp) path with **no SQL change** — identical to `coming`/`absent`. The only code that interprets the value is `parse_state`, which now handles `leaving`.

## Changes

- Migration widening the `model_filters.state` CHECK to include `leaving` (the down-migration collapses `leaving → absent` then narrows). Verified reversible.
- `ModelFilterState::Leaving` + `as_str`/`parse_state`.
- `current_filter_states()` trait method + Postgres impl; `.sqlx` cache regenerated.

## Tests

- A `leaving` model is treated as not-live (leaky bucket, ≤1 leaked).
- `current_filter_states()` returns `(state, since)` per model incl. `absent`; `leaving` round-trips through the log.
- Enum round-trip.

`cargo test` (model_filters suite incl. the unchanged purge test), `clippy`, `sqlx prepare --check`, and `fmt` are clean.

## Semver

Additive minor for the in-house consumer (it uses `Storage` over the concrete Postgres manager and does not match on `ModelFilterState`). Note for external `Storage` implementors: the trait gains a required method.
