### PR TITLE
feat: add per-creditor request-count queries for unverified upload limits

### DIFF
--- a/.sqlx/query-4fb673d433e357250c903514f2941b122a7b4893fff7d7738a760a09df49b941.json
+++ b/.sqlx/query-4fb673d433e357250c903514f2941b122a7b4893fff7d7738a760a09df49b941.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) AS \"count!\"\n            FROM requests\n            WHERE created_by = $1\n              AND created_at >= $2\n              AND service_tier = 'flex'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "4fb673d433e357250c903514f2941b122a7b4893fff7d7738a760a09df49b941"
+}

--- a/.sqlx/query-c12deb22e430dd1089000026f086cdf4b3ec46a9fe3784ee656a76d32afaccb0.json
+++ b/.sqlx/query-c12deb22e430dd1089000026f086cdf4b3ec46a9fe3784ee656a76d32afaccb0.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(total_requests), 0)::BIGINT AS \"total!\"\n            FROM batches\n            WHERE created_by = $1\n              AND completion_window = $2\n              AND created_at >= $3\n              AND deleted_at IS NULL\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "total!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c12deb22e430dd1089000026f086cdf4b3ec46a9fe3784ee656a76d32afaccb0"
+}

--- a/migrations/20260630000000_formalize_user_sort_indexes.down.sql
+++ b/migrations/20260630000000_formalize_user_sort_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_requests_user_created_sort;
+DROP INDEX IF EXISTS idx_requests_user_active_sort;

--- a/migrations/20260630000000_formalize_user_sort_indexes.up.sql
+++ b/migrations/20260630000000_formalize_user_sort_indexes.up.sql
@@ -11,7 +11,9 @@
 -- COR-481: the unverified upload-volume limit counts a user's recent flex
 -- requests with `WHERE created_by = $1 AND created_at >= $2 AND service_tier =
 -- 'flex'`; `idx_requests_user_created_sort` serves it as an index range scan
--- (seek created_by, range created_at, service_tier as an index condition).
+-- (seek created_by, range created_at). `service_tier = 'flex'` sits after the
+-- created_at range column, so it's a residual filter rather than a scan bound,
+-- but keeping it in the index lets the count stay index-only (no heap fetch).
 --
 -- A non-concurrent build holds ACCESS EXCLUSIVE on `requests` for its duration.
 -- Deployments that already ran the backfill script (and any copy-on-write

--- a/migrations/20260630000000_formalize_user_sort_indexes.up.sql
+++ b/migrations/20260630000000_formalize_user_sort_indexes.up.sql
@@ -1,0 +1,48 @@
+-- Formalize the two per-user batchless-request indexes into the migration set.
+--
+-- `idx_requests_user_active_sort` and `idx_requests_user_created_sort` back the
+-- per-user response listing, and now also the COR-481 unverified upload-volume
+-- count query. They were created out-of-band by
+-- `scripts/backfill_responses_to_batchless.sql` (CONCURRENTLY) during the
+-- batchless-responses rollout and were never added to a migration — so the
+-- migration history drifts from production, where both indexes exist. This
+-- migration reconciles that drift so fresh deploys get them too.
+--
+-- COR-481: the unverified upload-volume limit counts a user's recent flex
+-- requests with `WHERE created_by = $1 AND created_at >= $2 AND service_tier =
+-- 'flex'`; `idx_requests_user_created_sort` serves it as an index range scan
+-- (seek created_by, range created_at, service_tier as an index condition).
+--
+-- A non-concurrent build holds ACCESS EXCLUSIVE on `requests` for its duration.
+-- Deployments that already ran the backfill script (and any copy-on-write
+-- database branches taken from them) already have these indexes, so the
+-- `IF NOT EXISTS` statements below are a no-op there. For any other large
+-- deployment, create them CONCURRENTLY before deploying so these become no-ops:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_user_active_sort
+--   ON requests (
+--     created_by,
+--     (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+--     created_at DESC, id DESC, service_tier
+--   ) WHERE created_by IS NOT NULL;
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_user_created_sort
+--   ON requests (created_by, created_at DESC, id DESC, service_tier)
+--   WHERE created_by IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_user_active_sort
+ON requests (
+    created_by,
+    (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+    created_at DESC,
+    id DESC,
+    service_tier
+) WHERE created_by IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_user_created_sort
+ON requests (
+    created_by,
+    created_at DESC,
+    id DESC,
+    service_tier
+) WHERE created_by IS NOT NULL;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -16,6 +16,7 @@ use crate::request::{
     RequestListResult, RequestState, ServiceTierFilter,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use futures::stream::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -436,6 +437,46 @@ pub trait Storage: Send + Sync {
         priority_decay_window: Option<i64>,
         strict: bool,
     ) -> Result<HashMap<String, HashMap<String, i64>>>;
+
+    /// Sum the `total_requests` of a creditor's batches for a given completion
+    /// window created on or after `cutoff`.
+    ///
+    /// Used by the control layer to enforce the unverified upload-volume cap at
+    /// batch creation: an unverified creditor may submit at most
+    /// `unverified_requests_per_completion_hour * window_hours` requests within
+    /// a rolling window equal to the completion window. Served by
+    /// `idx_batches_completion_window (completion_window, created_by)`.
+    ///
+    /// - `owner`: the batch `created_by` — the creditor (organization id for org
+    ///   members, user id otherwise).
+    /// - `cutoff`: only batches with `created_at >= cutoff` are counted.
+    /// - `strict`: set `true` to read from the write pool and avoid read lag, so
+    ///   a just-created batch is reflected immediately (required for enforcement).
+    async fn sum_owner_batch_requests_in_window(
+        &self,
+        owner: &str,
+        completion_window: &str,
+        cutoff: DateTime<Utc>,
+        strict: bool,
+    ) -> Result<i64>;
+
+    /// Count a creditor's batchless `flex` requests created on or after `cutoff`.
+    ///
+    /// The flex counterpart of [`Storage::sum_owner_batch_requests_in_window`]:
+    /// flex requests are batchless (`batch_id IS NULL`, attribution via
+    /// `requests.created_by`) and always map to the 1h completion window. Served
+    /// by `idx_requests_user_created_sort (created_by, created_at DESC, id DESC,
+    /// service_tier) WHERE created_by IS NOT NULL`.
+    ///
+    /// - `owner`: the request `created_by` — the creditor id.
+    /// - `cutoff`: only requests with `created_at >= cutoff` are counted.
+    /// - `strict`: set `true` to read from the write pool and avoid read lag.
+    async fn count_owner_flex_requests_since(
+        &self,
+        owner: &str,
+        cutoff: DateTime<Utc>,
+        strict: bool,
+    ) -> Result<i64>;
     ///
     /// Cancel one or more individual pending or in-progress requests.
     ///

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -889,8 +889,10 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
 
         // created_by IS NOT NULL ⟺ batch_id IS NULL (requests_attribution_xor),
         // so filtering created_by already restricts to batchless rows. Served by
-        // idx_requests_user_created_sort: seek created_by, range created_at,
-        // service_tier as an index condition.
+        // idx_requests_user_created_sort: seek created_by, range created_at.
+        // service_tier = 'flex' is a residual filter, not a scan bound (it sits
+        // after the created_at range column in the index), but it stays in the
+        // index so the count can be served index-only without a heap fetch.
         let count = sqlx::query_scalar!(
             r#"
             SELECT COUNT(*) AS "count!"

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -831,6 +831,90 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
 /// If you need counts of all pending requests regardless of claimability, adjust the query
 /// to remove these filters.
 impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManager<P, H> {
+    async fn sum_owner_batch_requests_in_window(
+        &self,
+        owner: &str,
+        completion_window: &str,
+        cutoff: DateTime<Utc>,
+        strict: bool,
+    ) -> Result<i64> {
+        let pool = if strict {
+            self.pools.write()
+        } else {
+            self.pools.read()
+        };
+
+        // Equality on (completion_window, created_by) seeks
+        // idx_batches_completion_window; created_at and the SUM are a residual
+        // over one creditor's batches for one window (a tiny set). SUM over
+        // BIGINT yields NUMERIC, so cast back to BIGINT for an i64 binding.
+        let total = sqlx::query_scalar!(
+            r#"
+            SELECT COALESCE(SUM(total_requests), 0)::BIGINT AS "total!"
+            FROM batches
+            WHERE created_by = $1
+              AND completion_window = $2
+              AND created_at >= $3
+              AND deleted_at IS NULL
+            "#,
+            owner,
+            completion_window,
+            cutoff,
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to sum batch requests for creditor {} in window {}: {}",
+                owner,
+                completion_window,
+                e
+            ))
+        })?;
+
+        Ok(total)
+    }
+
+    async fn count_owner_flex_requests_since(
+        &self,
+        owner: &str,
+        cutoff: DateTime<Utc>,
+        strict: bool,
+    ) -> Result<i64> {
+        let pool = if strict {
+            self.pools.write()
+        } else {
+            self.pools.read()
+        };
+
+        // created_by IS NOT NULL ⟺ batch_id IS NULL (requests_attribution_xor),
+        // so filtering created_by already restricts to batchless rows. Served by
+        // idx_requests_user_created_sort: seek created_by, range created_at,
+        // service_tier as an index condition.
+        let count = sqlx::query_scalar!(
+            r#"
+            SELECT COUNT(*) AS "count!"
+            FROM requests
+            WHERE created_by = $1
+              AND created_at >= $2
+              AND service_tier = 'flex'
+            "#,
+            owner,
+            cutoff,
+        )
+        .fetch_one(pool)
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to count flex requests for creditor {}: {}",
+                owner,
+                e
+            ))
+        })?;
+
+        Ok(count)
+    }
+
     async fn get_pending_request_counts_by_model_and_window(
         &self,
         windows: &[(String, Option<i64>, i64)], // (label, start_secs, end_secs)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2555,3 +2555,185 @@ mod service_tier {
         assert_eq!(all_result.data.len(), 2);
     }
 }
+
+/// Tests for the per-creditor rolling-window count queries that back the
+/// control layer's unverified upload-volume cap (COR-481).
+mod unverified_volume_counts {
+    use super::*;
+
+    /// Create a batch attributed to `creditor` with `completion_window` and `n`
+    /// templated requests. The batch-status trigger sets `total_requests` to `n`
+    /// as the requests are populated.
+    async fn seed_batch<S: Storage>(
+        manager: &S,
+        creditor: &str,
+        completion_window: &str,
+        n: usize,
+    ) {
+        let templates: Vec<RequestTemplateInput> = (0..n)
+            .map(|_| RequestTemplateInput {
+                custom_id: None,
+                endpoint: "https://api.example.com".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/test".to_string(),
+                body: "{}".to_string(),
+                model: "test-model".to_string(),
+                api_key: "k".to_string(),
+            })
+            .collect();
+        let file_id = manager
+            .create_file(
+                format!("f-{creditor}-{completion_window}-{n}"),
+                None,
+                templates,
+            )
+            .await
+            .unwrap();
+        manager
+            .create_batch(BatchInput {
+                file_id,
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: completion_window.to_string(),
+                metadata: None,
+                created_by: Some(creditor.to_string()),
+                api_key_id: None,
+                api_key: None,
+                total_requests: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    async fn seed_flex<S: Storage>(manager: &S, creditor: &str) {
+        manager
+            .create_flex(fusillade::CreateFlexInput {
+                request_id: uuid::Uuid::new_v4(),
+                body: r#"{"prompt":"test"}"#.to_string(),
+                model: "test-model".to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: creditor.to_string(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_sum_owner_batch_requests_in_window(pool: sqlx::PgPool) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        );
+
+        // user-a: 3 requests in 24h, 2 in 1h. user-b: 5 in 24h (isolation).
+        seed_batch(&manager, "user-a", "24h", 3).await;
+        seed_batch(&manager, "user-a", "1h", 2).await;
+        seed_batch(&manager, "user-b", "24h", 5).await;
+
+        let past = chrono::Utc::now() - chrono::Duration::hours(48);
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+
+        // Scoped by creditor AND completion_window.
+        assert_eq!(
+            manager
+                .sum_owner_batch_requests_in_window("user-a", "24h", past, true)
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            manager
+                .sum_owner_batch_requests_in_window("user-a", "1h", past, true)
+                .await
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            manager
+                .sum_owner_batch_requests_in_window("user-b", "24h", past, true)
+                .await
+                .unwrap(),
+            5,
+            "other creditors must not bleed into the count"
+        );
+
+        // A future cutoff excludes the just-created batches.
+        assert_eq!(
+            manager
+                .sum_owner_batch_requests_in_window("user-a", "24h", future, true)
+                .await
+                .unwrap(),
+            0,
+            "created_at < cutoff must be excluded"
+        );
+
+        // Unknown creditor / window → 0.
+        assert_eq!(
+            manager
+                .sum_owner_batch_requests_in_window("nobody", "24h", past, true)
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_count_owner_flex_requests_since(pool: sqlx::PgPool) {
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        );
+
+        // user-a: two flex requests + one realtime (must be excluded). Plus a 1h
+        // BATCH (its requests are batched, not batchless flex) and a flex request
+        // for user-b — both must be excluded from user-a's flex count.
+        seed_flex(&manager, "user-a").await;
+        seed_flex(&manager, "user-a").await;
+        manager
+            .create_realtime(fusillade::CreateRealtimeInput {
+                request_id: uuid::Uuid::new_v4(),
+                body: r#"{"prompt":"test"}"#.to_string(),
+                model: "test-model".to_string(),
+                endpoint: "http://localhost".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/responses".to_string(),
+                api_key: String::new(),
+                created_by: "user-a".to_string(),
+            })
+            .await
+            .unwrap();
+        seed_batch(&manager, "user-a", "1h", 4).await;
+        seed_flex(&manager, "user-b").await;
+
+        let past = chrono::Utc::now() - chrono::Duration::hours(48);
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+
+        assert_eq!(
+            manager
+                .count_owner_flex_requests_since("user-a", past, true)
+                .await
+                .unwrap(),
+            2,
+            "counts only batchless flex rows: excludes realtime, batched 1h, and other creditors"
+        );
+        assert_eq!(
+            manager
+                .count_owner_flex_requests_since("user-b", past, true)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            manager
+                .count_owner_flex_requests_since("user-a", future, true)
+                .await
+                .unwrap(),
+            0,
+            "created_at < cutoff must be excluded"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Part of **COR-481** (unverified upload behaviour). The control layer needs to cap how many requests an *unverified* creditor can submit per completion window (e.g. 1,000/h async, 24,000/24h batch), and reject over-limit submissions with an actionable error. dwctl reads batch/request state only through the `Storage` trait, so the count queries live here.

## What

Two new `Storage` methods (single-table, index-served counts, meant to run only for unverified creditors at submission time):

- **`sum_owner_batch_requests_in_window(owner, completion_window, cutoff, strict)`** — `SUM(total_requests)` of a creditor's batches for a completion window since `cutoff`. Served by the existing `idx_batches_completion_window (completion_window, created_by)`.
- **`count_owner_flex_requests_since(owner, cutoff, strict)`** — `COUNT` of a creditor's batchless `flex` requests since `cutoff` (`created_by IS NOT NULL ⟺ batch_id IS NULL` via `requests_attribution_xor`, so this is exactly the batchless rows). Served by `idx_requests_user_created_sort`.

`strict=true` uses the write pool so a just-created row is reflected immediately (needed for enforcement).

## Index reconciliation

`idx_requests_user_active_sort` / `idx_requests_user_created_sort` were created out-of-band by `scripts/backfill_responses_to_batchless.sql` (`CONCURRENTLY`) and were **never added to the migration set**, despite existing in production. This PR formalizes them via `CREATE INDEX IF NOT EXISTS` + a `CONCURRENTLY` pre-create runbook (matching the convention in `20260610…`/`20260615…`), so it's a **no-op** wherever they already exist and fresh deploys get them too. No genuinely new index is introduced.

## Tests

`tests/integration.rs::unverified_volume_counts` — covers creditor isolation, completion-window scoping, the `cutoff` filter, and exclusion of realtime/batched rows from the flex count.

Local: `just lint` (fmt-check, clippy `-D warnings`, `sqlx prepare --check`) and the new tests pass against PG18.

## Release note

Adds methods to the public `Storage` trait (minor, per the `bulk_delete_data` precedent). dwctl uses `PostgresRequestManager` concretely and is unaffected. The control-layer side (enforcement) lands in a separate PR and depends on a release + version bump of this crate.