### PR TITLE
fix: stop logging provider response bodies in failure/retry logs

### DIFF
--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -5219,7 +5219,14 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
                             Some(body) => match serde_json::from_str(body) {
                                 Ok(json) => json,
                                 Err(e) => {
-                                    tracing::warn!("Failed to parse response body as JSON: {}", e);
+                                    // ZDR: log only the error location/category, never the
+                                    // serde message — it can echo a fragment of the body.
+                                    tracing::warn!(
+                                        line = e.line(),
+                                        column = e.column(),
+                                        category = ?e.classify(),
+                                        "Failed to parse response body as JSON"
+                                    );
                                     serde_json::Value::String(body.to_string())
                                 }
                             },

--- a/src/request/types.rs
+++ b/src/request/types.rs
@@ -277,18 +277,25 @@ impl FailureReason {
     }
 
     /// Returns a human-readable error message for this failure reason.
+    ///
+    /// ZDR: the upstream response `body` is intentionally NOT included — provider
+    /// error bodies can echo prompt/response content, and this message is emitted
+    /// to logs at the daemon's retry/failure sites. Only the status and the body
+    /// length are reported.
     pub fn to_error_message(&self) -> String {
         match self {
             FailureReason::RetriableHttpStatus { status, body } => {
                 format!(
-                    "HTTP request returned retriable status code: {} - {}",
-                    status, body
+                    "HTTP request returned retriable status code: {} ({}-byte body omitted)",
+                    status,
+                    body.len()
                 )
             }
             FailureReason::NonRetriableHttpStatus { status, body } => {
                 format!(
-                    "HTTP request returned error status code: {} - {}",
-                    status, body
+                    "HTTP request returned error status code: {} ({}-byte body omitted)",
+                    status,
+                    body.len()
                 )
             }
             FailureReason::NetworkError { error } => {
@@ -538,5 +545,41 @@ impl From<Request<Failed>> for AnyRequest {
 impl From<Request<Canceled>> for AnyRequest {
     fn from(r: Request<Canceled>) -> Self {
         AnyRequest::Canceled(r)
+    }
+}
+
+#[cfg(test)]
+mod zdr_logging_tests {
+    use super::*;
+
+    /// ZDR (COR-498): the human-readable error string fed to the daemon's
+    /// retry/failure logs must never contain the upstream provider response body.
+    #[test]
+    fn to_error_message_omits_provider_body() {
+        const SENTINEL: &str = "ZDR-SENTINEL-PROVIDER-BODY-7c1e";
+
+        for reason in [
+            FailureReason::RetriableHttpStatus {
+                status: 503,
+                body: format!("{{\"completion\":\"{SENTINEL}\"}}"),
+            },
+            FailureReason::NonRetriableHttpStatus {
+                status: 400,
+                body: format!("{{\"error\":\"{SENTINEL}\"}}"),
+            },
+        ] {
+            let msg = reason.to_error_message();
+            assert!(
+                !msg.contains(SENTINEL),
+                "provider response body leaked into error message: {msg}"
+            );
+            // The status must still be present so the log stays diagnostic.
+            assert!(
+                msg.contains(&reason.status_code_label()),
+                "expected status code in message, got: {msg}"
+            );
+            // And the message must be non-empty (daemon asserts this).
+            assert!(!msg.is_empty());
+        }
     }
 }

--- a/tests/request_processor.rs
+++ b/tests/request_processor.rs
@@ -288,10 +288,30 @@ async fn custom_processor_can_synthesize_terminal_failure(pool: sqlx::PgPool) {
     let AnyRequest::Failed(req) = fetch_any_request(&manager, request_id).await else {
         panic!("expected Failed variant");
     };
+
+    // The synthesized failure reason still carries the upstream body (it is
+    // persisted), proving the custom processor's terminal outcome propagated.
+    match &req.state.reason {
+        fusillade::request::FailureReason::NonRetriableHttpStatus { status, body } => {
+            assert_eq!(*status, 400, "synthesized status should propagate");
+            assert_eq!(
+                body, "synthetic test failure",
+                "synthesized body should propagate"
+            );
+        }
+        other => panic!("expected NonRetriableHttpStatus, got {other:?}"),
+    }
+
+    // ZDR: to_error_message() is scrubbed — it reports the status but must never
+    // echo the provider response body (see COR-498).
     let err = req.state.reason.to_error_message();
     assert!(
-        err.contains("synthetic test failure"),
-        "expected synthesized failure body in error: {err}"
+        err.contains("400"),
+        "status should appear in error message: {err}"
+    );
+    assert!(
+        !err.contains("synthetic test failure"),
+        "ZDR: provider body must not appear in to_error_message(): {err}"
     );
 
     shutdown_token.cancel();


### PR DESCRIPTION
## What & why

Part of the ZDR no-payload-logging work (**COR-498**, under COR-479). In production fusillade runs at `RUST_LOG=debug`, so `warn!` events ship to Loki/Tempo.

`FailureReason::to_error_message()` formatted `RetriableHttpStatus`/`NonRetriableHttpStatus` as `"<status> - <body>"`, embedding the **raw upstream provider response body**. It's emitted at the daemon's three retry/failure WARN sites (`daemon/mod.rs`), so every retriable/terminal HTTP failure leaked the provider body — which can echo prompt/response content — into logs.

## Changes

- **`request/types.rs`** — `to_error_message()` now reports `<status> (<n>-byte body omitted)` instead of the body. Fixes all three daemon log sites at once (the function is only used by those logs + test assertions; it is not persisted or returned to clients).
- **`manager/postgres.rs`** — the batch-output response-body parse-error `warn!` now logs the serde error's `line`/`column`/`category` instead of its `Display`, which can echo a fragment of the body. (The fallback that returns the body in the batch **output** file is unchanged — that's legitimate response delivery, not a log.)
- Added `to_error_message_omits_provider_body` unit test (sentinel body never appears; status still present; message non-empty).

## Tests

- `cargo check --lib` ✅ (offline) · `cargo clippy --lib` ✅ (no new warnings) · `cargo fmt --check` ✅
- New unit test passes (compiled/run against a local PG18 container). No SQL changed, so the `.sqlx` cache is untouched.

## Out of scope (tracked separately)

The same provider body is also serialized into the durable `requests.error` column (via `FailureReason`'s `Serialize`). That's persistence, not logging — it belongs to the ZDR encrypted-payload / scrubbed-row work (COR-479 Part 2), not this logging fix.

Follow-ups: COR-499 (control-layer error-path leaks), COR-500 (CI lint guard), COR-501 (cross-path sentinel harness).