### PR TITLE
fix: optimize pending request count query

### DIFF
--- a/migrations/20260630000000_add_claimable_batches_expiry_index.down.sql
+++ b/migrations/20260630000000_add_claimable_batches_expiry_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_batches_claimable_expiry;

--- a/migrations/20260630000000_add_claimable_batches_expiry_index.up.sql
+++ b/migrations/20260630000000_add_claimable_batches_expiry_index.up.sql
@@ -1,0 +1,11 @@
+CREATE INDEX IF NOT EXISTS idx_batches_claimable_expiry
+ON batches (expires_at)
+INCLUDE (id)
+WHERE cancelling_at IS NULL
+  AND deleted_at IS NULL
+  AND completed_at IS NULL
+  AND failed_at IS NULL
+  AND cancelled_at IS NULL;
+
+COMMENT ON INDEX idx_batches_claimable_expiry IS
+'Optimized for monitoring claimable batch queue depth by completion window';

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -914,17 +914,33 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             WITH windows(label, start_seconds, has_start, end_seconds) AS (
                 SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::int2[], $4::bigint[])
             ),
-            active_request_counts AS (
+            active_batches AS MATERIALIZED (
                 SELECT
-                    r.batch_id,
-                    r.model,
-                    COUNT(*)::BIGINT AS request_count
-                FROM requests r
+                    b.id,
+                    b.expires_at
+                FROM batches b
+                WHERE b.cancelling_at IS NULL
+                  AND b.deleted_at IS NULL
+                  AND b.completed_at IS NULL
+                  AND b.failed_at IS NULL
+                  AND b.cancelled_at IS NULL
+                  -- Row-level upper bound: a batch that expires after every
+                  -- window's end cannot contribute to any bucket, so prune it
+                  -- before touching request rows.
+                  AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
+            ),
+            batch_counts AS (
+                SELECT
+                    r.model as model,
+                    w.label as window_label,
+                    COUNT(*) FILTER (
+                        WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
+                          AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
+                    )::BIGINT as count
+                FROM active_batches b
+                JOIN requests r ON r.batch_id = b.id
+                CROSS JOIN windows w
                 WHERE r.state = ANY($5)
-                -- Batchless rows are counted by batchless_counts below; the
-                -- inner join in batch_counts would drop them anyway, so skip
-                -- scanning them here and keep the two CTEs disjoint.
-                AND r.batch_id IS NOT NULL
                 AND r.template_id IS NOT NULL
                 AND (cardinality($6::text[]) = 0 OR r.model = ANY($6))
                 AND (
@@ -938,37 +954,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                         OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($7))
                     ))
                 )
-                GROUP BY r.batch_id, r.model
-            ),
-            batch_counts AS (
-                SELECT
-                    arc.model as model,
-                    w.label as window_label,
-                    COALESCE(SUM(arc.request_count) FILTER (
-                        WHERE (w.has_start = 0 OR b.expires_at >= NOW() + make_interval(secs => w.start_seconds))
-                          AND b.expires_at < NOW() + make_interval(secs => w.end_seconds)
-                    ), 0)::BIGINT as count
-                FROM active_request_counts arc
-                JOIN batches b ON arc.batch_id = b.id
-                CROSS JOIN windows w
-                -- Only count rows the daemon can actually claim. This MUST stay in
-                -- sync with the batch eligibility filter in `claim_requests`
-                -- (`ranked_batches`): excluding only `cancelling_at` here while the
-                -- claim path also excludes terminal batches lets a `pending` row
-                -- stranded under an already-completed batch (e.g. a retry that
-                -- raced batch finalization) be reported as claimable forever while
-                -- never actually being claimed.
-                WHERE b.cancelling_at IS NULL
-                  AND b.deleted_at IS NULL
-                  AND b.completed_at IS NULL
-                  AND b.failed_at IS NULL
-                  AND b.cancelled_at IS NULL
-                -- Row-level upper bound: a row that expires after every window's
-                -- end can't contribute to any window's COUNT FILTER, so prune it
-                -- here. Without this, the join reads every active+templated
-                -- request and only filters inside the aggregate.
-                AND b.expires_at < NOW() + make_interval(secs => (SELECT MAX(end_seconds) FROM windows))
-                GROUP BY arc.model, w.label
+                GROUP BY r.model, w.label
             ),
             batchless_counts AS (
                 -- Daemon-claimable rows with no parent batch (flex/async


### PR DESCRIPTION
## Summary
- refresh the pending-count query against current main's window/service-tier/priority-decay implementation
- materialize claimable batches before joining requests, so terminal/cancelled batches are pruned before request aggregation
- add a tighter claimable-batch expiry index for the monitoring query path
- rely on current main's terminal-batch regression test, which verifies stranded pending rows are not reported as claimable

## Testing
- `DATABASE_URL=postgres://postgres:password@localhost:5432/fusillade_codex_pending_counts_rebased cargo test pending_request_counts -- --nocapture`
- `DATABASE_URL=postgres://postgres:password@localhost:5432/fusillade_codex_pending_counts_rebased cargo test pending_counts_exclude_terminal_batches -- --nocapture`
- `cargo fmt --check`
- `DATABASE_URL=postgres://postgres:password@localhost:5432/fusillade_codex_pending_counts_rebased cargo check`
- `DATABASE_URL=postgres://postgres:password@localhost:5432/fusillade_codex_pending_counts_rebased cargo sqlx prepare --check`