### PR TITLE
feat: add priority-class pending request counts

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -428,7 +428,7 @@ pub trait Storage: Send + Sync {
     /// Excludes:
     /// - Requests without a template_id
     /// - Requests in batches being cancelled
-    /// - Batched requests whose submitted completion window is not `"1h"` or `"24h"`
+    /// - Batched requests whose submitted completion window is `"1w"`
     async fn get_pending_request_counts_by_model_and_window(
         &self,
         windows: &[(String, Option<i64>, i64)],
@@ -448,7 +448,8 @@ pub trait Storage: Send + Sync {
     /// - `"24h"` -> `"24h"`
     /// - `"1w"` -> `"low_priority"`
     ///
-    /// Other submitted windows are ignored by this priority-class view.
+    /// Other submitted windows are ignored by this priority-class view, but
+    /// still count normally in deadline-window counts.
     ///
     /// Batchless flex rows are classified as `"1h"` and other non-priority
     /// batchless rows as `"24h"`, matching their synthesized claim deadlines.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -428,9 +428,32 @@ pub trait Storage: Send + Sync {
     /// Excludes:
     /// - Requests without a template_id
     /// - Requests in batches being cancelled
+    /// - Batched requests whose submitted completion window is not `"1h"` or `"24h"`
     async fn get_pending_request_counts_by_model_and_window(
         &self,
         windows: &[(String, Option<i64>, i64)],
+        states: &[String],
+        model_filter: &[String],
+        service_tier_filter: &ServiceTierFilter,
+        priority_decay_window: Option<i64>,
+        strict: bool,
+    ) -> Result<HashMap<String, HashMap<String, i64>>>;
+
+    /// Get request counts grouped by model and original SLA priority class.
+    ///
+    /// Unlike [`Storage::get_pending_request_counts_by_model_and_window`], this
+    /// classifies batched rows by the submitted `batches.completion_window`, not
+    /// by time remaining until `expires_at`:
+    /// - `"1h"` -> `"1h"`
+    /// - `"24h"` -> `"24h"`
+    /// - `"1w"` -> `"low_priority"`
+    ///
+    /// Other submitted windows are ignored by this priority-class view.
+    ///
+    /// Batchless flex rows are classified as `"1h"` and other non-priority
+    /// batchless rows as `"24h"`, matching their synthesized claim deadlines.
+    async fn get_pending_request_counts_by_model_and_priority_class(
+        &self,
         states: &[String],
         model_filter: &[String],
         service_tier_filter: &ServiceTierFilter,

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -1125,7 +1125,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                   AND b.completed_at IS NULL
                   AND b.failed_at IS NULL
                   AND b.cancelled_at IS NULL
-                  AND b.completion_window IN ('1h', '24h')
+                  AND b.completion_window IS DISTINCT FROM '1w'
                 -- Row-level upper bound: a row that expires after every window's
                 -- end can't contribute to any window's COUNT FILTER, so prune it
                 -- here. Without this, the join reads every active+templated
@@ -15112,9 +15112,11 @@ mod tests {
             !deadline_counts.contains_key("model-b"),
             "default deadline counts must filter out submitted 1w requests"
         );
-        assert!(
-            !deadline_counts.contains_key("model-c"),
-            "default deadline counts must filter out non-high-priority submitted windows"
+        assert_eq!(
+            deadline_counts
+                .get("model-c")
+                .and_then(|counts| counts.get("24h")),
+            Some(&1)
         );
         assert_eq!(
             deadline_counts
@@ -15198,7 +15200,7 @@ mod tests {
         let states = vec!["pending".to_string()];
         let model_filter: Vec<String> = vec![];
 
-        // Any: 0s priority batches are not part of deadline-window counts.
+        // Any: all three rows counted.
         let counts = manager
             .get_pending_request_counts_by_model_and_window(
                 &windows,
@@ -15210,7 +15212,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 3);
 
         // Exclude("priority"): batch + flex.
         let counts = manager
@@ -15254,8 +15256,7 @@ mod tests {
             .unwrap();
         assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
 
-        // Exclude batch tier (None represents NULL): flex only. The priority
-        // batch is filtered out by its submitted 0s completion window.
+        // Exclude batch tier (None represents NULL): flex + priority.
         let counts = manager
             .get_pending_request_counts_by_model_and_window(
                 &windows,
@@ -15267,7 +15268,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 1);
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
 
         // Empty Include matches nothing.
         let counts = manager

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -14992,6 +14992,145 @@ mod tests {
     }
 
     #[sqlx::test]
+    async fn test_pending_request_counts_priority_classes_only_count_1w_as_low_priority(
+        pool: sqlx::PgPool,
+    ) {
+        use chrono::Duration;
+
+        let http_client = Arc::new(MockHttpClient::new());
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool.clone()).await.unwrap(),
+            http_client,
+        );
+
+        let now = Utc::now();
+        for (model, completion_window, expires_at) in [
+            ("model-b", "1w", now + Duration::hours(23)),
+            ("model-c", "7d", now + Duration::hours(23)),
+            ("model-d", "24h", now + Duration::hours(23)),
+            ("model-e", "1h", now + Duration::minutes(50)),
+        ] {
+            let file_id = manager
+                .create_file(
+                    format!("file-{model}-{completion_window}"),
+                    None,
+                    vec![RequestTemplateInput {
+                        custom_id: Some(format!("{model}-{completion_window}")),
+                        endpoint: "/v1/chat/completions".to_string(),
+                        method: "POST".to_string(),
+                        path: "/v1/chat/completions".to_string(),
+                        body: r#"{"input":"x"}"#.to_string(),
+                        model: model.to_string(),
+                        api_key: "k".to_string(),
+                    }],
+                )
+                .await
+                .unwrap();
+
+            let batch = manager
+                .create_batch(BatchInput {
+                    file_id,
+                    endpoint: "/v1/chat/completions".to_string(),
+                    completion_window: completion_window.to_string(),
+                    metadata: None,
+                    created_by: None,
+                    api_key_id: None,
+                    api_key: None,
+                    total_requests: None,
+                })
+                .await
+                .unwrap();
+
+            sqlx::query("UPDATE batches SET expires_at = $1 WHERE id = $2")
+                .bind(expires_at)
+                .bind(*batch.id as Uuid)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let states = vec![
+            "pending".to_string(),
+            "claimed".to_string(),
+            "processing".to_string(),
+        ];
+        let model_filter: Vec<String> = vec![];
+        let exclude_priority = ServiceTierFilter::Exclude(vec![Some("priority".to_string())]);
+
+        let priority_counts = manager
+            .get_pending_request_counts_by_model_and_priority_class(
+                &states,
+                &model_filter,
+                &exclude_priority,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let model_b = priority_counts
+            .get("model-b")
+            .unwrap_or_else(|| panic!("expected model-b counts, got {priority_counts:?}"));
+        assert_eq!(model_b.get("1h"), Some(&0));
+        assert_eq!(model_b.get("24h"), Some(&0));
+        assert_eq!(model_b.get("low_priority"), Some(&1));
+        assert!(
+            !priority_counts.contains_key("model-c"),
+            "7d must not be treated as low priority"
+        );
+
+        let model_d = priority_counts
+            .get("model-d")
+            .unwrap_or_else(|| panic!("expected model-d counts, got {priority_counts:?}"));
+        assert_eq!(model_d.get("1h"), Some(&0));
+        assert_eq!(model_d.get("24h"), Some(&1));
+        assert_eq!(model_d.get("low_priority"), Some(&0));
+
+        let model_e = priority_counts
+            .get("model-e")
+            .unwrap_or_else(|| panic!("expected model-e counts, got {priority_counts:?}"));
+        assert_eq!(model_e.get("1h"), Some(&1));
+        assert_eq!(model_e.get("24h"), Some(&0));
+        assert_eq!(model_e.get("low_priority"), Some(&0));
+
+        let deadline_counts = manager
+            .get_pending_request_counts_by_model_and_window(
+                &[
+                    ("1h".to_string(), None, 3600),
+                    ("24h".to_string(), None, 86_400),
+                ],
+                &states,
+                &model_filter,
+                &exclude_priority,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !deadline_counts.contains_key("model-b"),
+            "default deadline counts must filter out submitted 1w requests"
+        );
+        assert!(
+            !deadline_counts.contains_key("model-c"),
+            "default deadline counts must filter out non-high-priority submitted windows"
+        );
+        assert_eq!(
+            deadline_counts
+                .get("model-d")
+                .and_then(|counts| counts.get("24h")),
+            Some(&1)
+        );
+        assert_eq!(
+            deadline_counts
+                .get("model-e")
+                .and_then(|counts| counts.get("1h")),
+            Some(&1)
+        );
+    }
+
+    #[sqlx::test]
     async fn test_pending_request_counts_service_tier_filter(pool: sqlx::PgPool) {
         use chrono::Duration;
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -15198,7 +15198,7 @@ mod tests {
         let states = vec!["pending".to_string()];
         let model_filter: Vec<String> = vec![];
 
-        // Any: all three rows counted.
+        // Any: 0s priority batches are not part of deadline-window counts.
         let counts = manager
             .get_pending_request_counts_by_model_and_window(
                 &windows,
@@ -15210,7 +15210,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 3);
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
 
         // Exclude("priority"): batch + flex.
         let counts = manager
@@ -15254,7 +15254,8 @@ mod tests {
             .unwrap();
         assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
 
-        // Exclude batch tier (None represents NULL): flex + priority.
+        // Exclude batch tier (None represents NULL): flex only. The priority
+        // batch is filtered out by its submitted 0s completion window.
         let counts = manager
             .get_pending_request_counts_by_model_and_window(
                 &windows,
@@ -15266,7 +15267,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 2);
+        assert_eq!(*counts.get("model-a").unwrap().get("1h").unwrap(), 1);
 
         // Empty Include matches nothing.
         let counts = manager

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -817,6 +817,31 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
 /// fails fast instead of accumulating behind the callers' poll cadence.
 const PENDING_COUNTS_STATEMENT_TIMEOUT_MS: i64 = 30_000;
 
+fn split_service_tier_filter(
+    service_tier_filter: &ServiceTierFilter,
+) -> (Vec<String>, bool, &'static str) {
+    match service_tier_filter {
+        ServiceTierFilter::Any => (Vec::new(), true, "any"),
+        ServiceTierFilter::Include(tiers) => {
+            let (names, has_null) = ServiceTierFilter::split(tiers);
+            (names, has_null, "include")
+        }
+        ServiceTierFilter::Exclude(tiers) => {
+            let (names, has_null) = ServiceTierFilter::split(tiers);
+            (names, has_null, "exclude")
+        }
+    }
+}
+
+fn priority_class_for_completion_window(window: &str) -> Option<&'static str> {
+    match window {
+        "1h" => Some("1h"),
+        "24h" => Some("24h"),
+        "1w" => Some("low_priority"),
+        _ => None,
+    }
+}
+
 // Implement Storage trait directly (no delegation)
 #[async_trait]
 /// Returns counts of **claimable** pending requests grouped by model and expiry window.
@@ -1100,6 +1125,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                   AND b.completed_at IS NULL
                   AND b.failed_at IS NULL
                   AND b.cancelled_at IS NULL
+                  AND b.completion_window IN ('1h', '24h')
                 -- Row-level upper bound: a row that expires after every window's
                 -- end can't contribute to any window's COUNT FILTER, so prune it
                 -- here. Without this, the join reads every active+templated
@@ -1214,6 +1240,227 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                 .try_get("count")
                 .map_err(|e| FusilladeError::Other(anyhow!("Failed to read count: {}", e)))?;
             result.entry(model).or_default().insert(window_label, count);
+        }
+
+        Ok(result)
+    }
+
+    async fn get_pending_request_counts_by_model_and_priority_class(
+        &self,
+        states: &[String],
+        model_filter: &[String],
+        service_tier_filter: &ServiceTierFilter,
+        priority_decay_window: Option<i64>,
+        strict: bool,
+    ) -> Result<HashMap<String, HashMap<String, i64>>> {
+        if states.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        if let Some(priority_decay_window) = priority_decay_window
+            && priority_decay_window < 0
+        {
+            return Err(FusilladeError::ValidationError(
+                "priority_decay_window must be non-negative".to_string(),
+            ));
+        }
+
+        let (tier_names, tier_include_null, tier_mode) =
+            split_service_tier_filter(service_tier_filter);
+
+        let mut tx = if strict {
+            self.pools.write().begin().await
+        } else {
+            self.pools.read().begin().await
+        }
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to begin transaction for priority-class pending request counts: {}",
+                e
+            ))
+        })?;
+
+        sqlx::query("SET LOCAL plan_cache_mode = force_custom_plan")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                FusilladeError::Other(anyhow!(
+                    "Failed to force custom plan for priority-class pending request counts: {}",
+                    e
+                ))
+            })?;
+
+        sqlx::query(&format!(
+            "SET LOCAL statement_timeout = {}",
+            PENDING_COUNTS_STATEMENT_TIMEOUT_MS
+        ))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to set statement_timeout for priority-class pending request counts: {}",
+                e
+            ))
+        })?;
+
+        let rows = sqlx::query(
+            r#"
+            WITH active_request_counts AS (
+                SELECT
+                    r.batch_id,
+                    r.model,
+                    COUNT(*)::BIGINT AS request_count
+                FROM requests r
+                WHERE r.state = ANY($1)
+                AND r.batch_id IS NOT NULL
+                AND r.template_id IS NOT NULL
+                AND (cardinality($2::text[]) = 0 OR r.model = ANY($2))
+                AND (
+                    $5 = 'any'
+                    OR ($5 = 'include' AND (
+                        (r.service_tier IS NOT NULL AND r.service_tier = ANY($3))
+                        OR ($4 AND r.service_tier IS NULL)
+                    ))
+                    OR ($5 = 'exclude' AND (
+                        (r.service_tier IS NULL AND NOT $4)
+                        OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($3))
+                    ))
+                )
+                GROUP BY r.batch_id, r.model
+            ),
+            batch_counts AS (
+                SELECT
+                    arc.model AS model,
+                    b.completion_window AS completion_window,
+                    NULL::text AS priority_class,
+                    COALESCE(SUM(arc.request_count), 0)::BIGINT AS count
+                FROM active_request_counts arc
+                JOIN batches b ON arc.batch_id = b.id
+                WHERE b.cancelling_at IS NULL
+                  AND b.deleted_at IS NULL
+                  AND b.completed_at IS NULL
+                  AND b.failed_at IS NULL
+                  AND b.cancelled_at IS NULL
+                  AND b.completion_window IN ('1h', '24h', '1w')
+                GROUP BY arc.model, b.completion_window
+            ),
+            batchless_rows AS (
+                SELECT
+                    r.model AS model,
+                    CASE WHEN r.service_tier = 'flex' THEN '1h' ELSE '24h' END AS priority_class
+                FROM requests r
+                WHERE r.batch_id IS NULL
+                AND r.state = ANY($1)
+                AND r.template_id IS NOT NULL
+                AND (cardinality($2::text[]) = 0 OR r.model = ANY($2))
+                AND (
+                    $5 = 'any'
+                    OR ($5 = 'include' AND (
+                        (r.service_tier IS NOT NULL AND r.service_tier = ANY($3))
+                        OR ($4 AND r.service_tier IS NULL)
+                    ))
+                    OR ($5 = 'exclude' AND (
+                        (r.service_tier IS NULL AND NOT $4)
+                        OR (r.service_tier IS NOT NULL AND r.service_tier <> ALL($3))
+                    ))
+                )
+            ),
+            batchless_counts AS (
+                SELECT
+                    model,
+                    NULL::text AS completion_window,
+                    priority_class,
+                    COUNT(*)::BIGINT AS count
+                FROM batchless_rows
+                GROUP BY model, priority_class
+            ),
+            priority_decay_counts AS (
+                SELECT
+                    r.model AS model,
+                    NULL::text AS completion_window,
+                    '1h'::text AS priority_class,
+                    COUNT(*)::BIGINT AS count
+                FROM requests r
+                WHERE $6::bigint IS NOT NULL
+                AND r.service_tier = 'flex'
+                AND r.state = 'completed'
+                AND r.template_id IS NOT NULL
+                AND r.completed_at >= NOW() - make_interval(secs => $6::bigint)
+                AND r.completed_at <= NOW()
+                AND (cardinality($2::text[]) = 0 OR r.model = ANY($2))
+                GROUP BY r.model
+            )
+            SELECT
+                model,
+                completion_window,
+                priority_class,
+                SUM(count)::BIGINT AS count
+            FROM (
+                SELECT * FROM batch_counts
+                UNION ALL
+                SELECT * FROM batchless_counts
+                UNION ALL
+                SELECT * FROM priority_decay_counts
+            ) counts
+            GROUP BY model, completion_window, priority_class
+            "#,
+        )
+        .bind(states)
+        .bind(model_filter)
+        .bind(&tier_names)
+        .bind(tier_include_null)
+        .bind(tier_mode)
+        .bind(priority_decay_window)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to get pending request counts by model and priority class: {}",
+                e
+            ))
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            FusilladeError::Other(anyhow!(
+                "Failed to commit priority-class pending request counts transaction: {}",
+                e
+            ))
+        })?;
+
+        let mut result: HashMap<String, HashMap<String, i64>> = HashMap::new();
+        for row in rows {
+            let model: String = row
+                .try_get("model")
+                .map_err(|e| FusilladeError::Other(anyhow!("Failed to read model: {}", e)))?;
+            let completion_window: Option<String> =
+                row.try_get("completion_window").map_err(|e| {
+                    FusilladeError::Other(anyhow!("Failed to read completion_window: {}", e))
+                })?;
+            let priority_class: Option<String> = row.try_get("priority_class").map_err(|e| {
+                FusilladeError::Other(anyhow!("Failed to read priority_class: {}", e))
+            })?;
+            let count: i64 = row
+                .try_get("count")
+                .map_err(|e| FusilladeError::Other(anyhow!("Failed to read count: {}", e)))?;
+
+            let class = priority_class.as_deref().or_else(|| {
+                completion_window
+                    .as_deref()
+                    .and_then(priority_class_for_completion_window)
+            });
+            if let Some(class) = class {
+                *result
+                    .entry(model)
+                    .or_default()
+                    .entry(class.to_string())
+                    .or_insert(0) += count;
+            }
+        }
+
+        for counts in result.values_mut() {
+            counts.entry("1h".to_string()).or_insert(0);
+            counts.entry("24h".to_string()).or_insert(0);
+            counts.entry("low_priority".to_string()).or_insert(0);
         }
 
         Ok(result)


### PR DESCRIPTION
## Summary

- add a priority-class pending request count API that buckets submitted `1h`, `24h`, and `1w` batch windows separately
- keep default deadline-window counts scoped to submitted `1h`/`24h` batches so low-priority windows do not inflate high-priority queue depth
- add and align Postgres tests for priority classes and service-tier filtering

