### PR TITLE
feat: pass the request to ResponseTransformer

### DIFF
--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -7747,6 +7747,22 @@ mod tests {
         }
     }
 
+    /// Test double that proves the *specific* request being persisted reaches the
+    /// hook: it records the id it was handed and echoes it into the body, so a test
+    /// can assert both that the transformer saw the right request (not some other
+    /// row) and that request fields can influence the transformed output.
+    struct RequestEchoTransformer {
+        seen: Arc<std::sync::Mutex<Option<Uuid>>>,
+    }
+
+    #[async_trait]
+    impl crate::transform::ResponseTransformer for RequestEchoTransformer {
+        async fn transform(&self, request: &RequestData, body: &str) -> Result<String> {
+            *self.seen.lock().unwrap() = Some(request.id.0);
+            Ok(format!("{}:{body}", request.id.0))
+        }
+    }
+
     /// Claim a single request into an in-flight state and hand back the request
     /// itself (so the caller can drive it to a terminal state and persist it),
     /// with an optional transformer installed on the manager. persist() matches
@@ -7877,6 +7893,36 @@ mod tests {
             calls.load(std::sync::atomic::Ordering::SeqCst),
             1,
             "transform must run exactly once per persist (it sits before the DB retry loop)",
+        );
+    }
+
+    /// The hook is handed the *specific* request being persisted, so an
+    /// implementation can read its fields and let them influence the output.
+    /// Guards against regressions that pass the wrong request (or none).
+    #[sqlx::test]
+    async fn response_transformer_receives_the_persisted_request(pool: sqlx::PgPool) {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let (manager, req) = claim_one_processing(
+            &pool,
+            Some(Arc::new(RequestEchoTransformer { seen: seen.clone() })),
+        )
+        .await;
+
+        manager
+            .persist(&completed_from(&req, "hello"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some(req.data.id.0),
+            "transformer must be handed the request being persisted",
+        );
+        let expected = format!("{}:hello", req.data.id.0);
+        assert_eq!(
+            stored_response_body(&pool, req.data.id).await.as_deref(),
+            Some(expected.as_str()),
+            "a field read from the passed request influenced the stored body",
         );
     }
 

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -1958,7 +1958,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
             match &mut any_request {
                 AnyRequest::Completed(req) => {
                     req.state.response_body = transformer
-                        .transform(req.data.id, &req.state.response_body)
+                        .transform(&req.data, &req.state.response_body)
                         .await?;
                 }
                 AnyRequest::Failed(req) => {
@@ -1970,7 +1970,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
                     match &mut req.state.reason {
                         FailureReason::RetriableHttpStatus { body, .. }
                         | FailureReason::NonRetriableHttpStatus { body, .. } => {
-                            *body = transformer.transform(req.data.id, body).await?;
+                            *body = transformer.transform(&req.data, body).await?;
                         }
                         _ => {}
                     }
@@ -7741,7 +7741,7 @@ mod tests {
 
     #[async_trait]
     impl crate::transform::ResponseTransformer for MarkingTransformer {
-        async fn transform(&self, _request_id: RequestId, body: &str) -> Result<String> {
+        async fn transform(&self, _request: &RequestData, body: &str) -> Result<String> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(format!("XFORM:{body}"))
         }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -18,13 +18,17 @@
 
 use async_trait::async_trait;
 
-use crate::{RequestId, Result};
+use crate::{RequestData, Result};
 
 /// Transforms a response or error body just before persistence. With no
 /// transformer installed (the default) the behaviour is identity.
 #[async_trait]
 pub trait ResponseTransformer: Send + Sync {
-    /// Return the body to persist for `request_id`. Implementations must return
-    /// the input unchanged when they do not apply to this request.
-    async fn transform(&self, request_id: RequestId, body: &str) -> Result<String>;
+    /// Return the body to persist for `request`. Implementations must return the
+    /// input unchanged when they do not apply to this request.
+    ///
+    /// `request` is the request being persisted - its id and `batch_metadata`
+    /// let an implementation decide whether (and how) to transform without a
+    /// separate lookup. `body` is the terminal response/error body to persist.
+    async fn transform(&self, request: &RequestData, body: &str) -> Result<String>;
 }


### PR DESCRIPTION
## What

Change `ResponseTransformer::transform` to receive the full `&RequestData` (id +
`batch_metadata` + the rest) instead of just the `RequestId`. Both persist call
sites and the in-repo test transformer are updated to match.

## Why

The transformer runs inside `persist()` on a terminal response, and it was only
handed the request id. dwctl's ZDR response encryptor (the sole implementor)
needs to know authoritatively whether the request is ZDR so it can fail closed -
refuse to persist a plaintext body when the per-request key is gone - instead of
inferring ZDR-ness from response-key presence (which fails open) or from the
stored body (already decrypted plaintext by that point).

That authoritative signal is a marker dwctl stamps on `batch_metadata`, which
already rides through to `persist()`. This change just stops the trait from
dropping it one hop early. Passing `&RequestData` keeps fusillade agnostic: it
forwards the request it already has, and the consumer decides what to read.

## Compatibility

This is a signature change to a public trait, but `ResponseTransformer` shipped
in 19.3.0 only hours ago and has a single in-repo consumer (dwctl), so there is
no real-world break. Shipped as a `feat` (minor bump) rather than a breaking
change.

## Testing

- `cargo fmt --check`, `cargo build`, and the lib test suite pass, including the
  existing `response_transformer_*` tests that drive the hook through `persist()`.
