### PR TITLE
fix: make pending request counts timeout configurable

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -174,6 +174,13 @@ pub struct DaemonConfig {
     /// and returned to pending (milliseconds). This handles daemon crashes during execution.
     pub processing_timeout_ms: u64,
 
+    /// PostgreSQL statement timeout for pending request count queries (milliseconds).
+    /// This bounds internal queue-depth monitoring work so a slow count query
+    /// fails without accumulating behind callers' poll cadence.
+    /// Default: 60,000 (60 seconds).
+    #[serde(default = "default_pending_request_counts_timeout_ms")]
+    pub pending_request_counts_timeout_ms: u64,
+
     /// Time after a daemon's last heartbeat before its requests are considered
     /// orphaned and returned to pending (milliseconds). Should be significantly
     /// larger than `heartbeat_interval_ms` to avoid reclaiming from live daemons
@@ -312,6 +319,10 @@ fn default_completion_window_ms() -> u64 {
     86_400_000 // 24 hours
 }
 
+fn default_pending_request_counts_timeout_ms() -> u64 {
+    60_000
+}
+
 fn default_claim_ramp_exponent() -> f64 {
     0.56
 }
@@ -347,10 +358,11 @@ impl Default for DaemonConfig {
             status_log_interval_ms: Some(2000), // Log every 2 seconds by default
             heartbeat_interval_ms: 5000,        // Heartbeat every 5 seconds by default
             should_retry: Arc::new(default_should_retry),
-            claim_timeout_ms: 60000,             // 1 minute
-            processing_timeout_ms: 600000,       // 10 minutes
-            stale_daemon_threshold_ms: 30_000,   // 30 seconds (6× heartbeat interval)
-            unclaim_batch_size: 100,             // Unclaim up to 100 stale requests per poll
+            claim_timeout_ms: 60000,       // 1 minute
+            processing_timeout_ms: 600000, // 10 minutes
+            pending_request_counts_timeout_ms: default_pending_request_counts_timeout_ms(),
+            stale_daemon_threshold_ms: 30_000, // 30 seconds (6× heartbeat interval)
+            unclaim_batch_size: 100,           // Unclaim up to 100 stale requests per poll
             cancellation_poll_interval_ms: 5000, // Poll every 5 seconds by default
             batch_metadata_fields: default_batch_metadata_fields(),
             purge_interval_ms: 600_000, // 10 minutes
@@ -1423,6 +1435,14 @@ mod tests {
     use crate::manager::{DaemonExecutor, postgres::PostgresRequestManager};
     use std::time::Duration;
 
+    #[test]
+    fn default_pending_request_counts_timeout_is_sixty_seconds() {
+        assert_eq!(
+            DaemonConfig::default().pending_request_counts_timeout_ms,
+            60_000
+        );
+    }
+
     #[sqlx::test]
     #[test_log::test]
     async fn test_daemon_claims_and_completes_request(pool: sqlx::PgPool) {
@@ -1461,6 +1481,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -1648,6 +1669,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -1897,6 +1919,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -2051,6 +2074,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -2244,6 +2268,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -2421,6 +2446,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -2598,6 +2624,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![
@@ -2773,6 +2800,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![
@@ -2884,6 +2912,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![
@@ -3049,6 +3078,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],
@@ -3190,6 +3220,7 @@ mod tests {
             should_retry: Arc::new(default_should_retry),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 30_000,
             unclaim_batch_size: 100,
             batch_metadata_fields: vec![],

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -320,6 +320,10 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
         self
     }
 
+    fn pending_counts_statement_timeout_ms(&self) -> i64 {
+        self.config.pending_request_counts_timeout_ms as i64
+    }
+
     /// Set the download buffer size for file content streams.
     ///
     /// This is a builder method that can be chained after `new()` or `with_client()`.
@@ -828,12 +832,6 @@ impl<P: PoolProvider, H: HttpClient + 'static> PostgresRequestManager<P, H> {
     }
 }
 
-/// Statement timeout for `get_pending_request_counts_by_model_and_window`.
-/// The query normally runs sub-second on a custom plan; this bounds the blast
-/// radius if a plan ever regresses to a sequential scan, so a single call
-/// fails fast instead of accumulating behind the callers' poll cadence.
-const PENDING_COUNTS_STATEMENT_TIMEOUT_MS: i64 = 30_000;
-
 // Implement Storage trait directly (no delegation)
 #[async_trait]
 /// Returns counts of **claimable** pending requests grouped by model and expiry window.
@@ -1039,7 +1037,7 @@ impl<P: PoolProvider, H: HttpClient + 'static> Storage for PostgresRequestManage
 
         sqlx::query(&format!(
             "SET LOCAL statement_timeout = {}",
-            PENDING_COUNTS_STATEMENT_TIMEOUT_MS
+            self.pending_counts_statement_timeout_ms()
         ))
         .execute(&mut *tx)
         .await
@@ -6611,6 +6609,21 @@ mod tests {
         }
     }
 
+    #[sqlx::test]
+    async fn pending_request_counts_statement_timeout_uses_manager_config(pool: sqlx::PgPool) {
+        let config = DaemonConfig {
+            pending_request_counts_timeout_ms: 12_345,
+            ..DaemonConfig::default()
+        };
+        let manager = PostgresRequestManager::with_client(
+            TestDbPools::new(pool).await.unwrap(),
+            Arc::new(MockHttpClient::new()),
+        )
+        .with_config(config);
+
+        assert_eq!(manager.pending_counts_statement_timeout_ms(), 12_345);
+    }
+
     // =========================================================================
     // sanitize_outbound_body — unit tests for the storage-layer body strip
     // =========================================================================
@@ -9129,6 +9142,7 @@ mod tests {
         let config = crate::daemon::DaemonConfig {
             claim_timeout_ms: 600000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 1000, // 1 second for testing
             ..Default::default()
         };
@@ -9231,6 +9245,7 @@ mod tests {
         let config = crate::daemon::DaemonConfig {
             claim_timeout_ms: 600000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 1000, // 1 second for testing
             ..Default::default()
         };
@@ -9333,6 +9348,7 @@ mod tests {
         let config = crate::daemon::DaemonConfig {
             claim_timeout_ms: 600000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60_000,
             stale_daemon_threshold_ms: 60000, // 1 minute
             ..Default::default()
         };


### PR DESCRIPTION
## Summary
- Add a configurable pending request counts statement timeout to daemon config
- Increase the default timeout from 30s to 60s
- Use the configured timeout when running pending request count queries

## Testing
- cargo test pending_request_counts --lib
- cargo test --no-run