### PR TITLE
fix: bound cancellation poll and purge queries against silent connect…

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1540,6 +1540,9 @@ where
         let storage = self.storage.clone();
         let shutdown_token = self.shutdown_token.clone();
         let cancellation_poll_interval_ms = self.config.cancellation_poll_interval_ms;
+        // Same deadness detector as the claim loops — these queries are all
+        // bounded, so a hit can only mean a dead connection.
+        let poll_query_timeout = Duration::from_millis(self.config.claim_query_timeout_ms);
 
         tokio::spawn(async move {
             let mut interval =
@@ -1566,8 +1569,18 @@ where
                         gauge!("fusillade_cancellation_poll_batches_checked")
                             .set(active_batch_ids.len() as f64);
 
-                        // Single bulk query to find which active batches have been cancelled
-                        match storage.get_cancelled_batch_ids(&active_batch_ids).await {
+                        // Single bulk query to find which active batches have been cancelled.
+                        // Bounded like the claim queries: a PK-set lookup can never
+                        // legitimately run long, but a silently severed connection wedged
+                        // this poll for ~25 min twice on 2026-07-09 (a stuck poll means
+                        // cancelled batches keep spending and finalization stalls).
+                        match with_query_timeout(
+                            "cancellation poll query",
+                            poll_query_timeout,
+                            storage.get_cancelled_batch_ids(&active_batch_ids),
+                        )
+                        .await
+                        {
                             Ok(cancelled_ids) => {
                                 for batch_id in cancelled_ids {
                                     if let Some(entry) = cancellation_tokens.get(&batch_id) {
@@ -1608,6 +1621,7 @@ where
             let purge_interval_ms = self.config.purge_interval_ms;
             let purge_batch_size = self.config.purge_batch_size;
             let purge_throttle_ms = self.config.purge_throttle_ms;
+            let purge_query_timeout = Duration::from_millis(self.config.claim_query_timeout_ms);
             let mf_keep_per_model = self.config.model_filters_keep_per_model;
             let mf_retention_secs = self.config.model_filters_retention_ms as f64 / 1000.0;
 
@@ -1631,7 +1645,13 @@ where
 
                     // Drain orphaned rows in batches
                     loop {
-                        match storage.purge_orphaned_rows(purge_batch_size).await {
+                        match with_query_timeout(
+                            "orphan purge query",
+                            purge_query_timeout,
+                            storage.purge_orphaned_rows(purge_batch_size),
+                        )
+                        .await
+                        {
                             Ok(0) => break,
                             Ok(deleted) => {
                                 counter!("fusillade_rows_purged_total").increment(deleted);
@@ -1656,13 +1676,16 @@ where
                     // keeping the latest events per model + the retention
                     // window so the claim gate never loses current state.
                     loop {
-                        match storage
-                            .purge_model_filter_events(
+                        match with_query_timeout(
+                            "model_filters purge query",
+                            purge_query_timeout,
+                            storage.purge_model_filter_events(
                                 purge_batch_size,
                                 mf_keep_per_model,
                                 mf_retention_secs,
-                            )
-                            .await
+                            ),
+                        )
+                        .await
                         {
                             Ok(0) => break,
                             Ok(deleted) => {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -176,17 +176,20 @@ pub struct DaemonConfig {
     #[serde(default = "default_claim_loop_max_consecutive_failures")]
     pub claim_loop_max_consecutive_failures: u32,
 
-    /// Upper bound on a single claim-cycle database query, in milliseconds.
-    /// This is a deadness detector, not a performance guardrail: claim
-    /// queries normally complete in seconds, but a connection severed
-    /// silently (compute restart, NAT/conntrack drop — nothing delivered to
-    /// the client) leaves the await blocked until TCP keepalive (hours),
-    /// freezing the claim loop inside a healthy-looking pod (observed
-    /// 2026-07-08, staging ×2 + prod). On expiry the in-flight connection is
-    /// dropped and the attempt counts as a transient claim failure, so the
-    /// retry/backoff machinery recovers on a fresh connection. Keep this
-    /// comfortably above any legitimate claim duration (worst ever observed:
-    /// ~101s p95, 2026-07-03, pre-split). Default: 180000 (3 minutes).
+    /// Upper bound on the daemon's periodic database queries, in
+    /// milliseconds: the claim-cycle queries, the cancellation/finalization
+    /// poll, and the purge loops. This is a deadness detector, not a
+    /// performance guardrail: these queries normally complete in seconds,
+    /// but a connection severed silently (compute restart, NAT/conntrack
+    /// drop — nothing delivered to the client) leaves the await blocked
+    /// until TCP keepalive (hours), freezing the loop inside a
+    /// healthy-looking pod (observed 2026-07-08, staging ×2 + prod). On
+    /// expiry the in-flight connection is dropped and the attempt counts as
+    /// a transient failure for that loop's existing error handling (claim
+    /// loops retry with backoff; poll/purge log and pick up on the next
+    /// tick). Keep this comfortably above any legitimate claim duration
+    /// (worst ever observed: ~101s p95, 2026-07-03, pre-split).
+    /// Default: 180000 (3 minutes).
     #[serde(default = "default_claim_query_timeout_ms")]
     pub claim_query_timeout_ms: u64,
 
@@ -1541,7 +1544,8 @@ where
         let shutdown_token = self.shutdown_token.clone();
         let cancellation_poll_interval_ms = self.config.cancellation_poll_interval_ms;
         // Same deadness detector as the claim loops — these queries are all
-        // bounded, so a hit can only mean a dead connection.
+        // bounded, so a timeout strongly suggests a dead/stalled connection
+        // (or a stalled pool acquisition), never a legitimately long query.
         let poll_query_timeout = Duration::from_millis(self.config.claim_query_timeout_ms);
 
         tokio::spawn(async move {


### PR DESCRIPTION
…ion loss

Extends the 20.0.2 query-timeout treatment to the remaining daemon DB loops. The cancellation/finalization poll wedged twice on 2026-07-09 (~25 min each, correlated with connection-severance events) because its query hung on a silently severed socket — a stuck poll means cancelled batches keep spending and finalization stalls. These queries are all bounded (PK-set lookup, LIMIT'd purges), so the timeout can only fire on a dead connection; reuses claim_query_timeout_ms (default 180s). All paths log-and-continue on error, so a timeout costs one poll tick.