### PR TITLE
ci: publish workspace crates independently

### DIFF
--- a/.github/scripts/publish-crate.sh
+++ b/.github/scripts/publish-crate.sh
@@ -37,6 +37,7 @@ crate_version_available() {
   local crate="$1"
   local version="$2"
   curl --fail --silent --show-error \
+    --user-agent "fusillade-release-script (https://github.com/doublewordai/fusillade)" \
     "https://crates.io/api/v1/crates/${crate}/${version}" \
     >/dev/null
 }

--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+saw_user_agent=0
+for arg in "$@"; do
+  case "$arg" in
+    --user-agent | --user-agent=* | -A | User-Agent:*)
+      saw_user_agent=1
+      ;;
+  esac
+done
+
+if [[ "$saw_user_agent" != 1 ]]; then
+  echo "curl was called without a User-Agent" >&2
+  exit 22
+fi
+STUB
+
+cat >"$tmpdir/cargo" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "cargo should not be called when the crate version is already available" >&2
+exit 1
+STUB
+
+chmod +x "$tmpdir/curl" "$tmpdir/cargo"
+
+core_version="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' crates/fusillade-core/Cargo.toml | head -n 1)"
+PATH="$tmpdir:$PATH" .github/scripts/publish-crate.sh "fusillade-core-v${core_version}"
+
+publish_job_block="$(awk '
+  /^  publish:/ { in_publish = 1; print; next }
+  in_publish && /^  [A-Za-z0-9_-]+:/ { in_publish = 0 }
+  in_publish { print }
+' .github/workflows/ci.yaml)"
+
+if grep -q '^[[:space:]]*concurrency:' <<<"$publish_job_block"; then
+  echo "publish job should not use a shared concurrency group; dependent crates must be able to wait and publish concurrently" >&2
+  exit 1
+fi
+
+if ! grep -q 'inputs.release_tag' .github/workflows/ci.yaml; then
+  echo "publish workflow should support manually dispatching a specific release tag" >&2
+  exit 1
+fi
+
+if ! grep -q 'bash .release-tools/.github/scripts/publish-crate.sh "$RELEASE_TAG"' .github/workflows/ci.yaml; then
+  echo "publish workflow should run release tooling from the current workflow branch, not the checked-out release tag" >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish to crates.io
+        required: false
+        type: string
 
 jobs:
   test:
@@ -56,18 +61,21 @@ jobs:
         run: just ci
 
   publish:
-    if: github.event_name == 'release' && !github.event.release.prerelease
+    if: (github.event_name == 'release' && !github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: depot-ubuntu-24.04
     needs: test
-    concurrency:
-      group: crates-io-publish
-      cancel-in-progress: false
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+
+      - name: Checkout release tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .release-tools
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -77,5 +85,5 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: .github/scripts/publish-crate.sh "$RELEASE_TAG"
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
+        run: bash .release-tools/.github/scripts/publish-crate.sh "$RELEASE_TAG"

--- a/justfile
+++ b/justfile
@@ -34,6 +34,9 @@ db-setup:
 test *args="":
     cargo test {{args}}
 
+test-release-scripts:
+    bash .github/scripts/test-publish-crate.sh
+
 # Lint
 lint:
     cargo fmt --check
@@ -46,6 +49,7 @@ fmt:
 
 # CI pipeline
 ci:
+    just test-release-scripts
     just db-setup
     cargo llvm-cov --lcov --output-path lcov.info
     just lint


### PR DESCRIPTION
## Summary
- send an explicit User-Agent when probing crates.io so dependency waits can detect newly published crate versions
- remove the shared publish concurrency group so each release tag can publish independently while the script waits for declared crate dependencies
- run publish tooling from the current workflow branch, so old release tags can be republished with fixed tooling instead of the stale script embedded in the tag
- add a `workflow_dispatch` `release_tag` input for manually publishing existing release tags
- add a release-script regression test and run it from `just ci`

## Verification
- `just test-release-scripts`
- `bash -n .github/scripts/publish-crate.sh .github/scripts/test-publish-crate.sh`
- `git diff --check`
- crates.io API probe for `fusillade-core 1.0.0` with the release-script User-Agent

## Notes
This addresses the failed `fusillade-arsenal-v1.0.0` publish run, where crates.io returned 403 to the dependency availability probe and the root crate publish was cancelled behind the shared publish concurrency group. After this merges, use the CI workflow dispatch with `release_tag` to republish the existing tags such as `fusillade-arsenal-v1.0.0` and `fusillade-v21.0.0`.