### PR TITLE
fix: allow arsenal package verify to skip during lockstep releases

### DIFF
--- a/.github/scripts/test-arsenal-sqlx-cache.sh
+++ b/.github/scripts/test-arsenal-sqlx-cache.sh
@@ -39,7 +39,7 @@ fi
 # Skip ONLY on an explicit 404 (version genuinely unpublished — the lockstep
 # case). Any other outcome (network failure, 429, 5xx) must fail the job
 # rather than silently degrade the verify coverage.
-status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
   --user-agent "fusillade-release-script (https://github.com/doublewordai/fusillade)" \
   "https://crates.io/api/v1/crates/fusillade-core/${core_version}" || true)"
 if [[ "$status" == "200" ]]; then

--- a/.github/scripts/test-arsenal-sqlx-cache.sh
+++ b/.github/scripts/test-arsenal-sqlx-cache.sh
@@ -31,11 +31,23 @@ fi
 # time, gated behind wait_for_crate_version in publish-crate.sh, so nothing
 # ships unverified.
 core_version="$(sed -n 's/^fusillade-core = { version = "\([^"]*\)".*/\1/p' crates/fusillade-arsenal/Cargo.toml | head -n 1)"
-if curl --fail --silent \
+if [[ -z "${core_version}" ]]; then
+  echo "Could not determine the fusillade-core version from crates/fusillade-arsenal/Cargo.toml." >&2
+  exit 1
+fi
+
+# Skip ONLY on an explicit 404 (version genuinely unpublished — the lockstep
+# case). Any other outcome (network failure, 429, 5xx) must fail the job
+# rather than silently degrade the verify coverage.
+status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
   --user-agent "fusillade-release-script (https://github.com/doublewordai/fusillade)" \
-  "https://crates.io/api/v1/crates/fusillade-core/${core_version}" >/dev/null; then
+  "https://crates.io/api/v1/crates/fusillade-core/${core_version}" || true)"
+if [[ "$status" == "200" ]]; then
   cargo package --package fusillade-arsenal --allow-dirty
-else
+elif [[ "$status" == "404" ]]; then
   echo "fusillade-core ${core_version} is not on crates.io yet (lockstep release);"
   echo "skipping the package verify build — publish-time verification still applies."
+else
+  echo "Failed to query crates.io for fusillade-core ${core_version} (HTTP ${status:-unknown})." >&2
+  exit 1
 fi

--- a/.github/scripts/test-arsenal-sqlx-cache.sh
+++ b/.github/scripts/test-arsenal-sqlx-cache.sh
@@ -22,4 +22,20 @@ if ! grep -q '^\.sqlx/query-.*\.json$' <<<"$package_list"; then
   exit 1
 fi
 
-cargo package --package fusillade-arsenal --allow-dirty
+# The full package (verify build in isolation) resolves fusillade-core from
+# crates.io. During a lockstep release that bumps core and arsenal together,
+# the required core version is not published until AFTER the release PR
+# merges (tags trigger the publishes), so this step cannot pass on the
+# release PR itself — a chicken-and-egg, first hit by the 1.1.0 release.
+# Skipping is safe: cargo publish runs the identical verify build at publish
+# time, gated behind wait_for_crate_version in publish-crate.sh, so nothing
+# ships unverified.
+core_version="$(sed -n 's/^fusillade-core = { version = "\([^"]*\)".*/\1/p' crates/fusillade-arsenal/Cargo.toml | head -n 1)"
+if curl --fail --silent \
+  --user-agent "fusillade-release-script (https://github.com/doublewordai/fusillade)" \
+  "https://crates.io/api/v1/crates/fusillade-core/${core_version}" >/dev/null; then
+  cargo package --package fusillade-arsenal --allow-dirty
+else
+  echo "fusillade-core ${core_version} is not on crates.io yet (lockstep release);"
+  echo "skipping the package verify build — publish-time verification still applies."
+fi


### PR DESCRIPTION
The release PR's CI runs cargo package on fusillade-arsenal, whose verify build resolves fusillade-core from crates.io. When a release bumps core and arsenal together (first hit: core 1.1.0 + arsenal 1.1.0), the required core version only publishes AFTER the release PR merges — a chicken-and-egg that blocks the release PR's CI forever.

The .sqlx-inclusion check (cargo package --list) is unaffected and still mandatory. The full verify build now runs whenever the required core version is available on crates.io and is skipped otherwise; nothing ships unverified because cargo publish performs the identical verify build at publish time, gated behind wait_for_crate_version in publish-crate.sh.