### PR TITLE
fix: preserve independent workspace crate versions

### DIFF
--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -59,3 +59,32 @@ if ! grep -q 'bash .release-tools/.github/scripts/publish-crate.sh "$RELEASE_TAG
   echo "publish workflow should run release tooling from the current workflow branch, not the checked-out release tag" >&2
   exit 1
 fi
+
+if grep -q '"always-link-local"[[:space:]]*:[[:space:]]*true' release-please-config.json; then
+  echo "release-please must not bump unreleased local workspace crates" >&2
+  exit 1
+fi
+
+manifest_version() {
+  sed -n 's/^version = "\([^"]*\)".*/\1/p' "$1" | head -n 1
+}
+
+release_manifest_version() {
+  local package_path="$1"
+  awk -v key="\"${package_path}\":" '
+    $1 == key {
+      gsub(/[\",]/, "", $2)
+      print $2
+    }
+  ' .release-please-manifest.json
+}
+
+for package_path in crates/fusillade-core crates/fusillade-arsenal; do
+  declared_version="$(manifest_version "${package_path}/Cargo.toml")"
+  released_version="$(release_manifest_version "$package_path")"
+
+  if [[ "$declared_version" != "$released_version" ]]; then
+    echo "${package_path}/Cargo.toml declares ${declared_version}, but release-please tracks ${released_version}" >&2
+    exit 1
+  fi
+done

--- a/crates/fusillade-arsenal/Cargo.toml
+++ b/crates/fusillade-arsenal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fusillade-arsenal"
 edition = "2024"
-version = "21.1.2"
+version = "1.1.0"
 description = "PostgreSQL storage implementation for the Fusillade scheduling daemon"
 license = "MIT OR Apache-2.0"
 
@@ -10,7 +10,7 @@ name = "fusillade_arsenal"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "21.1.2", path = "../fusillade-core", features = ["sqlx-postgres"] }
+fusillade-core = { version = "1.1.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/crates/fusillade-core/Cargo.toml
+++ b/crates/fusillade-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fusillade-core"
 edition = "2024"
-version = "21.1.2"
+version = "1.1.0"
 description = "Core domain types and storage traits for Fusillade"
 license = "MIT OR Apache-2.0"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "release-type": "rust",
   "include-component-in-tag": true,
   "tag-separator": "-",
-  "always-link-local": true,
   "plugins": ["cargo-workspace"],
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- keep `fusillade-core` and `fusillade-arsenal` at the versions tracked for their independent release components
- stop root-crate releases from automatically rewriting every local workspace dependency version
- fail the release-script tests when workspace package manifests drift from the Release Please manifest or local packages are forcibly linked

## Why

The root `fusillade` 21.1.2 release commit also rewrote the two independently released workspace crates to 21.1.2. Those versions did not exist in the registry, so Cargo could not resolve the release-tag workspace and the publish workflow stopped during its test job.

## Verification

- `just ci`
  - release-script and packaged SQLx-cache checks passed
  - 27 unit tests passed
  - 28 integration, package-boundary, and request-processor tests passed
  - formatting, Clippy, and SQLx metadata checks passed
