### PR TITLE
fix: drop cargo-workspace plugin that stamps unreleased crates with f…

### DIFF
--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -99,7 +99,9 @@ done
 # major. This check forces the manual requirement bump into the same release.
 dependency_requirement() {
   local manifest="$1" crate="$2"
-  sed -n "s/^${crate} = { version = \"\([^\"]*\)\".*/\1/p" "$manifest" | head -n 1
+  # Tolerant of indentation and inline-table field order (path before
+  # version, etc.); still anchored so other crate names can't match.
+  sed -n "s/^[[:space:]]*${crate}[[:space:]]*=.*version[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$manifest" | head -n 1
 }
 
 major_of() {
@@ -109,6 +111,11 @@ major_of() {
 while read -r manifest crate tracked_path; do
   requirement="$(dependency_requirement "$manifest" "$crate")"
   tracked="$(release_manifest_version "$tracked_path")"
+
+  if [[ -z "$tracked" ]]; then
+    echo "could not find tracked version for ${tracked_path} in .release-please-manifest.json" >&2
+    exit 1
+  fi
 
   if [[ -z "$requirement" ]]; then
     echo "could not find internal dependency ${crate} in ${manifest}" >&2

--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -73,7 +73,7 @@ release_manifest_version() {
   local package_path="$1"
   awk -v key="\"${package_path}\":" '
     $1 == key {
-      gsub(/[\",]/, "", $2)
+      gsub(/[",]/, "", $2)
       print $2
     }
   ' .release-please-manifest.json
@@ -88,3 +88,39 @@ for package_path in crates/fusillade-core crates/fusillade-arsenal; do
     exit 1
   fi
 done
+
+# Internal dependency requirements must stay resolvable against the versions
+# release-please tracks. With the cargo-workspace plugin removed (it kept
+# stamping unreleased crates with other crates' versions — see #345 and #350),
+# nothing rewrites these requirement strings automatically. That is fine for
+# minor/patch releases: `version = "1.1.1"` means ^1.1.1 and resolves newer
+# 1.x automatically. It is NOT fine across a MAJOR bump — a stale ^1.x
+# requirement would make a published dependent silently build against the old
+# major. This check forces the manual requirement bump into the same release.
+dependency_requirement() {
+  local manifest="$1" crate="$2"
+  sed -n "s/^${crate} = { version = \"\([^\"]*\)\".*/\1/p" "$manifest" | head -n 1
+}
+
+major_of() {
+  echo "${1%%.*}"
+}
+
+while read -r manifest crate tracked_path; do
+  requirement="$(dependency_requirement "$manifest" "$crate")"
+  tracked="$(release_manifest_version "$tracked_path")"
+
+  if [[ -z "$requirement" ]]; then
+    echo "could not find internal dependency ${crate} in ${manifest}" >&2
+    exit 1
+  fi
+
+  if [[ "$(major_of "$requirement")" != "$(major_of "$tracked")" ]]; then
+    echo "${manifest} requires ${crate} ^${requirement}, but release-please tracks ${tracked}: bump the requirement in the same release as the major bump" >&2
+    exit 1
+  fi
+done <<'DEPS'
+Cargo.toml fusillade-core crates/fusillade-core
+Cargo.toml fusillade-arsenal crates/fusillade-arsenal
+crates/fusillade-arsenal/Cargo.toml fusillade-core crates/fusillade-core
+DEPS

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "release-type": "rust",
   "include-component-in-tag": true,
   "tag-separator": "-",
-  "plugins": ["cargo-workspace"],
   "packages": {
     ".": {
       "component": "fusillade",


### PR DESCRIPTION
…oreign versions

The plugin adds every workspace manifest to the release's update set (to rewrite internal dependency requirements) and stamps each file with its candidate release's version. Any crate WITHOUT its own release in the cycle gets another crate's version written into package.version:

- release 21.1.2: only root released -> BOTH sub-crates stamped 21.1.2 (reverted by #345, which added the drift tripwire but kept the plugin)
- release PR #350: root + arsenal released -> arsenal's own write won, and core (no release) was stamped with the root's 21.2.0 -- caught by the #345 tripwire, which fails that PR's CI

Same defect both times; it fires whenever any member doesn't release, i.e. most cycles.

What the plugin provided and why nothing is lost:
- internal requirement bumps: version = "1.1.1" is ^1.1.1 and resolves newer 1.x automatically at build/publish; only MAJOR bumps need the requirement edited, and a new guard check fails CI when an internal requirement's major diverges from the tracked version, forcing that edit into the same release
- publish ordering: already handled by the tri-state crates.io probe

Also fixes the awk warning ('regexp escape sequence \"') in the manifest-parsing helper.

Merging this to main makes release-please regenerate the open release PR without the rogue core edit.