### PR TITLE
fix: resolve internal dependency requirements against the 2.0.0 major release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ name = "fusillade"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "1.1.1", path = "crates/fusillade-core" }
-fusillade-arsenal = { version = "1.1.1", path = "crates/fusillade-arsenal", optional = true }
+fusillade-core = { version = "2.0.0", path = "crates/fusillade-core" }
+fusillade-arsenal = { version = "2.0.0", path = "crates/fusillade-arsenal", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
 tracing = "0.1"

--- a/crates/fusillade-arsenal/Cargo.toml
+++ b/crates/fusillade-arsenal/Cargo.toml
@@ -10,7 +10,7 @@ name = "fusillade_arsenal"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "1.1.1", path = "../fusillade-core", features = ["sqlx-postgres"] }
+fusillade-core = { version = "2.0.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
## Problem

Release #356 performed a major bump — `fusillade-core` and `fusillade-arsenal` to **2.0.0**, root `fusillade` to **22.0.0** — but left the intra-workspace dependency **requirement strings** pointing at `1.1.1`:

- `Cargo.toml` → `fusillade-core = "1.1.1"`, `fusillade-arsenal = "1.1.1"`
- `crates/fusillade-arsenal/Cargo.toml` → `fusillade-core = "1.1.1"`

The root package uses `release-type: simple` (marker-only version bump) and the cargo-workspace plugin was removed in #345/#350, so nothing rewrites these strings automatically — on a **major** bump they must be updated by hand.

`^1.1.1` cannot resolve a `2.0.0` crate, so the `test-publish-crate.sh` guard failed every release job:

```
Cargo.toml requires fusillade-core ^1.1.1, but release-please tracks 2.0.0:
bump the requirement in the same release as the major bump
```

Nothing published to crates.io — the index still tops out at `fusillade 21.2.1 / fusillade-core 1.1.1 / fusillade-arsenal 1.2.1`. The `22.0.0` / `2.0.0` tags and releases are orphaned.

## Fix

Bump the three internal requirement strings to `2.0.0` so the workspace resolves and the crates can publish.

## Verification

- `.github/scripts/test-publish-crate.sh` now exits 0
- `cargo build --all-features` compiles `fusillade-core 2.0.0`, `fusillade-arsenal 2.0.0`, `fusillade 22.0.0`
- `Cargo.lock` already consistent (no change)

## Follow-up

This greens `main`, but the orphaned tags still hold the broken manifests, so the actual publish will go through the release-please PR (re-cut the trio as a consistent patch and publish core → arsenal → root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)