### PR TITLE
fix: raise internal dependency minimums to the released 2.1.0 versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ name = "fusillade"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "2.0.0", path = "crates/fusillade-core" }
-fusillade-arsenal = { version = "2.0.1", path = "crates/fusillade-arsenal", optional = true }
+fusillade-core = { version = "2.1.0", path = "crates/fusillade-core" }
+fusillade-arsenal = { version = "2.1.0", path = "crates/fusillade-arsenal", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
 tracing = "0.1"

--- a/crates/fusillade-arsenal/Cargo.toml
+++ b/crates/fusillade-arsenal/Cargo.toml
@@ -10,7 +10,7 @@ name = "fusillade_arsenal"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "2.0.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
+fusillade-core = { version = "2.1.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
fusillade 22.1.0 consumes API introduced in fusillade-core/arsenal 2.1.0 (ArchiveOutcome, the archive storage methods), and arsenal 2.1.0 re-exports core 2.1.0 types — but the published requirements still permitted 2.0.x, which satisfies resolution while failing to compile (Codex review on the release PR). Requirements now state the true minimums.

This could not land before the release: path+version dependencies validate against the path crate's actual manifest version, so requiring 2.1.0 breaks the workspace build until the release commit bumps the versions. Post-release follow-up is the honest pattern until release tooling rewrites internal requirements inside the release commit itself.