### PR TITLE
fix!: bound the request upload phase with a progress watchdog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["json", "stream"] }
+bytes = "1"
+http-body = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"

--- a/crates/fusillade-core/src/error.rs
+++ b/crates/fusillade-core/src/error.rs
@@ -62,6 +62,13 @@ pub enum FusilladeError {
     #[error("First chunk timeout: {0}")]
     FirstChunkTimeout(String),
 
+    /// The request body upload made no progress for the configured stall window.
+    /// Distinguishes send-phase hangs (a wedged connection or a stalled write)
+    /// from a slow-to-respond upstream, which is governed by first_chunk_timeout:
+    /// uploading a request should take seconds even when the answer takes hours.
+    #[error("Upload stall timeout: {0}")]
+    UploadStallTimeout(String),
+
     /// Timed out waiting for the next chunk of response body tokens (streaming only)
     #[error("Tokens timeout: {0}")]
     TokensTimeout(String),

--- a/crates/fusillade-core/src/request/transitions.rs
+++ b/crates/fusillade-core/src/request/transitions.rs
@@ -450,6 +450,9 @@ impl Request<Processing> {
                     FusilladeError::FirstChunkTimeout(msg) => {
                         FailureReason::Timeout { error: msg.clone() }
                     }
+                    FusilladeError::UploadStallTimeout(msg) => {
+                        FailureReason::Timeout { error: msg.clone() }
+                    }
                     FusilladeError::TokensTimeout(msg) => {
                         FailureReason::Timeout { error: msg.clone() }
                     }

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -140,8 +140,31 @@ pub struct DaemonConfig {
     pub backoff_ms: u64,
     pub backoff_factor: u64,
     pub max_backoff_ms: u64,
+    /// Maximum request-body upload idle time, in milliseconds.
+    ///
+    /// This watchdog covers outbound body progress for both streaming and
+    /// non-streaming requests. Keep it lower than `first_chunk_timeout_ms`:
+    /// both clocks can run during `send()`, and whichever expires first
+    /// determines the reported timeout.
+    #[serde(default = "default_upload_stall_timeout_ms")]
+    pub upload_stall_timeout_ms: u64,
+    /// Maximum time to the first streaming response event, in milliseconds.
+    ///
+    /// This includes connection setup, request upload, response headers, and
+    /// the first event. For non-streaming requests it contributes to the
+    /// combined overall request timeout with `body_timeout_ms`.
     pub first_chunk_timeout_ms: u64,
+    /// Maximum idle time between subsequent SSE events, in milliseconds.
+    ///
+    /// This only applies to endpoints listed in `streamable_endpoints` and
+    /// starts after the first event has arrived.
     pub chunk_timeout_ms: u64,
+    /// Maximum total response-body collection time, in milliseconds.
+    ///
+    /// For streaming requests this runs across the complete SSE collection
+    /// phase, alongside the per-event `chunk_timeout_ms`. For non-streaming
+    /// requests it contributes to the combined overall request timeout with
+    /// `first_chunk_timeout_ms`.
     pub body_timeout_ms: u64,
     pub status_log_interval_ms: Option<u64>,
     pub heartbeat_interval_ms: u64,
@@ -264,6 +287,10 @@ fn default_claim_query_timeout_ms() -> u64 {
     180_000
 }
 
+fn default_upload_stall_timeout_ms() -> u64 {
+    crate::http::DEFAULT_UPLOAD_STALL_TIMEOUT.as_millis() as u64
+}
+
 fn default_archive_sweep_interval_ms() -> u64 {
     5_000
 }
@@ -320,6 +347,7 @@ impl Default for DaemonConfig {
             backoff_ms: 1000,
             backoff_factor: 2,
             max_backoff_ms: 10000,
+            upload_stall_timeout_ms: default_upload_stall_timeout_ms(),
             first_chunk_timeout_ms: 540_000,
             chunk_timeout_ms: 540_000,
             body_timeout_ms: 60_000,
@@ -530,5 +558,31 @@ mod tests {
 
             assert_eq!(deserialized.additional_retryable_statuses, statuses);
         }
+    }
+
+    #[test]
+    fn upload_stall_timeout_defaults_when_missing() {
+        let mut serialized = serde_json::to_value(DaemonConfig::default()).unwrap();
+        serialized
+            .as_object_mut()
+            .unwrap()
+            .remove("upload_stall_timeout_ms");
+
+        let config: DaemonConfig = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(config.upload_stall_timeout_ms, 60_000);
+    }
+
+    #[test]
+    fn upload_stall_timeout_explicit_value_round_trips() {
+        let config = DaemonConfig {
+            upload_stall_timeout_ms: 12_345,
+            ..DaemonConfig::default()
+        };
+
+        let serialized = serde_json::to_value(config).unwrap();
+        let deserialized: DaemonConfig = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(deserialized.upload_stall_timeout_ms, 12_345);
     }
 }

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -145,9 +145,26 @@ pub struct DaemonConfig {
     /// This watchdog covers outbound body progress for both streaming and
     /// non-streaming requests. Keep it lower than `first_chunk_timeout_ms`:
     /// both clocks can run during `send()`, and whichever expires first
-    /// determines the reported timeout.
+    /// determines the reported timeout. Progress is observed in
+    /// `upload_chunk_bytes` units and checked every `upload_stall_poll_ms`.
     #[serde(default = "default_upload_stall_timeout_ms")]
     pub upload_stall_timeout_ms: u64,
+    /// Request-body bytes per upload progress unit.
+    ///
+    /// Smaller values detect incremental progress more finely but create more
+    /// body frames. Larger values reduce framing overhead but require a full
+    /// unit to be accepted before the watchdog observes progress. Must be
+    /// greater than zero.
+    #[serde(default = "default_upload_chunk_bytes")]
+    pub upload_chunk_bytes: usize,
+    /// How often the upload stall watchdog checks progress, in milliseconds.
+    ///
+    /// A stalled upload may be aborted up to roughly this long after
+    /// `upload_stall_timeout_ms` expires. Keep this well below the stall
+    /// timeout so it does not materially delay detection. Must be greater
+    /// than zero.
+    #[serde(default = "default_upload_stall_poll_ms")]
+    pub upload_stall_poll_ms: u64,
     /// Maximum time to the first streaming response event, in milliseconds.
     ///
     /// This includes connection setup, request upload, response headers, and
@@ -291,6 +308,14 @@ fn default_upload_stall_timeout_ms() -> u64 {
     crate::http::DEFAULT_UPLOAD_STALL_TIMEOUT.as_millis() as u64
 }
 
+fn default_upload_chunk_bytes() -> usize {
+    crate::http::DEFAULT_UPLOAD_CHUNK_BYTES
+}
+
+fn default_upload_stall_poll_ms() -> u64 {
+    crate::http::DEFAULT_UPLOAD_STALL_POLL.as_millis() as u64
+}
+
 fn default_archive_sweep_interval_ms() -> u64 {
     5_000
 }
@@ -348,6 +373,8 @@ impl Default for DaemonConfig {
             backoff_factor: 2,
             max_backoff_ms: 10000,
             upload_stall_timeout_ms: default_upload_stall_timeout_ms(),
+            upload_chunk_bytes: default_upload_chunk_bytes(),
+            upload_stall_poll_ms: default_upload_stall_poll_ms(),
             first_chunk_timeout_ms: 540_000,
             chunk_timeout_ms: 540_000,
             body_timeout_ms: 60_000,
@@ -561,22 +588,28 @@ mod tests {
     }
 
     #[test]
-    fn upload_stall_timeout_defaults_when_missing() {
+    fn upload_watchdog_defaults_when_missing() {
         let mut serialized = serde_json::to_value(DaemonConfig::default()).unwrap();
-        serialized
-            .as_object_mut()
-            .unwrap()
-            .remove("upload_stall_timeout_ms");
+        {
+            let serialized = serialized.as_object_mut().unwrap();
+            serialized.remove("upload_stall_timeout_ms");
+            serialized.remove("upload_chunk_bytes");
+            serialized.remove("upload_stall_poll_ms");
+        }
 
         let config: DaemonConfig = serde_json::from_value(serialized).unwrap();
 
         assert_eq!(config.upload_stall_timeout_ms, 60_000);
+        assert_eq!(config.upload_chunk_bytes, 64 * 1024);
+        assert_eq!(config.upload_stall_poll_ms, 100);
     }
 
     #[test]
-    fn upload_stall_timeout_explicit_value_round_trips() {
+    fn upload_watchdog_explicit_values_round_trip() {
         let config = DaemonConfig {
             upload_stall_timeout_ms: 12_345,
+            upload_chunk_bytes: 8 * 1024,
+            upload_stall_poll_ms: 25,
             ..DaemonConfig::default()
         };
 
@@ -584,5 +617,7 @@ mod tests {
         let deserialized: DaemonConfig = serde_json::from_value(serialized).unwrap();
 
         assert_eq!(deserialized.upload_stall_timeout_ms, 12_345);
+        assert_eq!(deserialized.upload_chunk_bytes, 8 * 1024);
+        assert_eq!(deserialized.upload_stall_poll_ms, 25);
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -163,15 +163,34 @@ pub trait HttpClient: Send + Sync + Clone {
 /// - `first_chunk_timeout`: max time to first token (connect + headers + first body chunk)
 /// - `chunk_timeout`: max idle time between subsequent body chunks
 /// - `body_timeout`: max total time for the entire response body
+///
+/// In both modes the request body upload is additionally bounded by
+/// `upload_stall_timeout` (default 60s): if the transport accepts no body
+/// bytes for that long before the upload completes, the attempt is aborted
+/// with [`FusilladeError::UploadStallTimeout`] so the retry machinery can
+/// dispatch a fresh one. This keeps send-phase hangs (a wedged connection,
+/// a stalled write) from silently consuming the much longer response
+/// timeouts, which are sized for slow upstreams rather than slow uploads.
 #[derive(Clone)]
 pub struct ReqwestHttpClient {
     client: reqwest::Client,
     first_chunk_timeout: Duration,
     chunk_timeout: Duration,
     body_timeout: Duration,
+    upload_stall_timeout: Duration,
     stream_reassembler: Option<StreamReassembler>,
     streamable_endpoints: Vec<String>,
 }
+
+/// Default cap on how long a request body upload may make no progress.
+const DEFAULT_UPLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Request bodies are handed to the transport in chunks of this size so the
+/// upload watchdog can observe progress.
+const UPLOAD_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Poll interval for the upload stall watchdog.
+const UPLOAD_STALL_POLL: Duration = Duration::from_millis(100);
 
 impl ReqwestHttpClient {
     /// Create a new reqwest-based HTTP client with the given timeouts.
@@ -186,9 +205,19 @@ impl ReqwestHttpClient {
             first_chunk_timeout,
             chunk_timeout,
             body_timeout,
+            upload_stall_timeout: DEFAULT_UPLOAD_STALL_TIMEOUT,
             stream_reassembler: Some(openai_reassembler::reassemble),
             streamable_endpoints,
         }
+    }
+
+    /// Override how long the request body upload may make no progress before
+    /// the attempt is aborted (default 60s). This bounds only the send phase;
+    /// how long the upstream may take to answer is governed by the other
+    /// timeouts.
+    pub fn with_upload_stall_timeout(mut self, timeout: Duration) -> Self {
+        self.upload_stall_timeout = timeout;
+        self
     }
 
     /// Set a stream reassembler function that converts collected SSE events
@@ -322,16 +351,25 @@ impl HttpClient for ReqwestHttpClient {
             tracing::trace!(request_id = %request.id, traceparent = %traceparent, "Added traceparent header for distributed tracing");
         }
 
-        // Only add body and Content-Type for methods that support a body
+        // Only add body and Content-Type for methods that support a body.
+        // The body is wrapped so the upload watchdog can observe progress;
+        // its exact size hint preserves Content-Length framing on the wire.
+        let mut upload: Option<Arc<UploadProgress>> = None;
         let method_upper = request.method.to_uppercase();
         if method_upper != "GET"
             && method_upper != "HEAD"
             && method_upper != "DELETE"
             && !request.body.is_empty()
         {
+            let body = bytes::Bytes::from(request.body.clone().into_bytes());
+            let progress = UploadProgress::new(body.len() as u64);
             req = req
                 .header("Content-Type", "application/json")
-                .body(request.body.clone());
+                .body(reqwest::Body::wrap(ProgressBody {
+                    remaining: body,
+                    progress: progress.clone(),
+                }));
+            upload = Some(progress);
             tracing::trace!(
                 request_id = %request.id,
                 body_len = request.body.len(),
@@ -343,9 +381,144 @@ impl HttpClient for ReqwestHttpClient {
         span.set_attribute("fusillade.streaming", stream);
         if stream {
             req = req.header("X-Fusillade-Stream", "true");
-            self.execute_streaming(request, req, &url, on_event).await
+            self.execute_streaming(request, req, &url, upload, on_event)
+                .await
         } else {
-            self.execute_non_streaming(request, req, &url).await
+            self.execute_non_streaming(request, req, &url, upload).await
+        }
+    }
+}
+
+/// Shared view of request-body upload progress between the instrumented body
+/// and the watchdog racing the send future.
+struct UploadProgress {
+    started: std::time::Instant,
+    last_progress_ms: std::sync::atomic::AtomicU64,
+    sent: std::sync::atomic::AtomicU64,
+    total: u64,
+    handed_off: std::sync::atomic::AtomicBool,
+}
+
+impl UploadProgress {
+    fn new(total: u64) -> Arc<Self> {
+        Arc::new(Self {
+            started: std::time::Instant::now(),
+            last_progress_ms: std::sync::atomic::AtomicU64::new(0),
+            sent: std::sync::atomic::AtomicU64::new(0),
+            total,
+            handed_off: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    fn record(&self, bytes: usize) {
+        use std::sync::atomic::Ordering;
+        self.sent.fetch_add(bytes as u64, Ordering::Relaxed);
+        self.last_progress_ms
+            .store(self.started.elapsed().as_millis() as u64, Ordering::Relaxed);
+    }
+
+    fn finish(&self) {
+        self.handed_off
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn is_handed_off(&self) -> bool {
+        self.handed_off.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn stalled_for(&self) -> Duration {
+        let last = Duration::from_millis(
+            self.last_progress_ms
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
+        self.started.elapsed().saturating_sub(last)
+    }
+
+    fn sent_bytes(&self) -> u64 {
+        self.sent.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Request body that reports upload progress to an [`UploadProgress`] handle.
+///
+/// The body is handed to the transport in [`UPLOAD_CHUNK_BYTES`] chunks; each
+/// chunk the transport accepts counts as progress. The exact `size_hint`
+/// preserves Content-Length framing, so the wire format is identical to
+/// sending the buffered body directly.
+struct ProgressBody {
+    remaining: bytes::Bytes,
+    progress: Arc<UploadProgress>,
+}
+
+impl http_body::Body for ProgressBody {
+    type Data = bytes::Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<std::result::Result<http_body::Frame<Self::Data>, Self::Error>>>
+    {
+        let this = self.get_mut();
+        if this.remaining.is_empty() {
+            this.progress.finish();
+            return std::task::Poll::Ready(None);
+        }
+        let take = this.remaining.len().min(UPLOAD_CHUNK_BYTES);
+        let chunk = this.remaining.split_to(take);
+        this.progress.record(take);
+        if this.remaining.is_empty() {
+            // The final chunk is now owned by the transport; from here on the
+            // request is waiting on the upstream, which the response timeouts
+            // govern.
+            this.progress.finish();
+        }
+        std::task::Poll::Ready(Some(Ok(http_body::Frame::data(chunk))))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.remaining.is_empty()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        http_body::SizeHint::with_exact(self.remaining.len() as u64)
+    }
+}
+
+/// Race `send` against an upload stall watchdog.
+///
+/// The watchdog fires only while the body is still being handed to the
+/// transport: if no chunk is accepted for `stall_timeout`, the attempt is
+/// aborted so the daemon's retry machinery can dispatch a fresh one. Once the
+/// body is fully handed off the watchdog disarms and `send`'s own timeouts
+/// take over. Requests without a body (`upload` is `None`) are unaffected.
+async fn race_upload_stall<T>(
+    send: impl std::future::Future<Output = T>,
+    upload: Option<Arc<UploadProgress>>,
+    stall_timeout: Duration,
+    url: &str,
+) -> Result<T> {
+    let Some(progress) = upload else {
+        return Ok(send.await);
+    };
+    tokio::pin!(send);
+    loop {
+        tokio::select! {
+            out = &mut send => return Ok(out),
+            _ = tokio::time::sleep(UPLOAD_STALL_POLL) => {
+                if progress.is_handed_off() {
+                    return Ok(send.await);
+                }
+                if progress.stalled_for() >= stall_timeout {
+                    return Err(crate::error::FusilladeError::UploadStallTimeout(format!(
+                        "request upload to {} stalled: {} of {} bytes handed to the transport, no progress for {}ms",
+                        url,
+                        progress.sent_bytes(),
+                        progress.total,
+                        stall_timeout.as_millis(),
+                    )));
+                }
+            }
         }
     }
 }
@@ -359,9 +532,25 @@ impl ReqwestHttpClient {
         request: &RequestData,
         req: reqwest::RequestBuilder,
         url: &str,
+        upload: Option<Arc<UploadProgress>>,
     ) -> Result<HttpResponse> {
         let total_timeout = self.first_chunk_timeout + self.body_timeout;
-        let response = req.timeout(total_timeout).send().await.map_err(|e| {
+        let response = race_upload_stall(
+            req.timeout(total_timeout).send(),
+            upload,
+            self.upload_stall_timeout,
+            url,
+        )
+        .await
+        .inspect_err(|e| {
+            tracing::error!(
+                request_id = %request.id,
+                url.full = %url,
+                error = %e,
+                "HTTP request upload stalled"
+            );
+        })?
+        .map_err(|e| {
             if e.is_builder() {
                 tracing::error!(
                     request_id = %request.id,
@@ -412,15 +601,17 @@ impl ReqwestHttpClient {
         request: &RequestData,
         req: reqwest::RequestBuilder,
         url: &str,
+        upload: Option<Arc<UploadProgress>>,
         on_event: Option<Arc<dyn StreamEventCallback>>,
     ) -> Result<HttpResponse> {
         use eventsource_stream::Eventsource;
         use futures::StreamExt;
 
         // Phase 1: connect, get headers, and wait for the first SSE event within
-        // one shared first_chunk_timeout deadline (time-to-first-token).
+        // one shared first_chunk_timeout deadline (time-to-first-token). The
+        // upload watchdog separately bounds the body send phase.
         let first_chunk_deadline = tokio::time::Instant::now() + self.first_chunk_timeout;
-        let resp = tokio::time::timeout_at(first_chunk_deadline, async {
+        let send = tokio::time::timeout_at(first_chunk_deadline, async {
             req.send()
                 .await
                 .map_err(map_reqwest_error)
@@ -434,15 +625,24 @@ impl ReqwestHttpClient {
                         "HTTP request failed"
                     );
                 })
-        })
-        .await
-        .map_err(|_| {
-            crate::error::FusilladeError::FirstChunkTimeout(format!(
-                "No response headers from {} within {}ms",
-                url,
-                self.first_chunk_timeout.as_millis()
-            ))
-        })??;
+        });
+        let resp = race_upload_stall(send, upload, self.upload_stall_timeout, url)
+            .await
+            .inspect_err(|e| {
+                tracing::error!(
+                    request_id = %request.id,
+                    url.full = %url,
+                    error = %e,
+                    "HTTP request upload stalled"
+                );
+            })?
+            .map_err(|_| {
+                crate::error::FusilladeError::FirstChunkTimeout(format!(
+                    "No response headers from {} within {}ms",
+                    url,
+                    self.first_chunk_timeout.as_millis()
+                ))
+            })??;
 
         let status = resp.status().as_u16();
         let content_type = resp

--- a/src/http.rs
+++ b/src/http.rs
@@ -178,6 +178,8 @@ pub struct ReqwestHttpClient {
     chunk_timeout: Duration,
     body_timeout: Duration,
     upload_stall_timeout: Duration,
+    upload_chunk_bytes: usize,
+    upload_stall_poll: Duration,
     stream_reassembler: Option<StreamReassembler>,
     streamable_endpoints: Vec<String>,
 }
@@ -187,10 +189,10 @@ pub(crate) const DEFAULT_UPLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(60
 
 /// Request bodies are handed to the transport in chunks of this size so the
 /// upload watchdog can observe progress.
-const UPLOAD_CHUNK_BYTES: usize = 64 * 1024;
+pub(crate) const DEFAULT_UPLOAD_CHUNK_BYTES: usize = 64 * 1024;
 
 /// Poll interval for the upload stall watchdog.
-const UPLOAD_STALL_POLL: Duration = Duration::from_millis(100);
+pub(crate) const DEFAULT_UPLOAD_STALL_POLL: Duration = Duration::from_millis(100);
 
 impl ReqwestHttpClient {
     /// Create a new reqwest-based HTTP client with the given timeouts.
@@ -206,6 +208,8 @@ impl ReqwestHttpClient {
             chunk_timeout,
             body_timeout,
             upload_stall_timeout: DEFAULT_UPLOAD_STALL_TIMEOUT,
+            upload_chunk_bytes: DEFAULT_UPLOAD_CHUNK_BYTES,
+            upload_stall_poll: DEFAULT_UPLOAD_STALL_POLL,
             stream_reassembler: Some(openai_reassembler::reassemble),
             streamable_endpoints,
         }
@@ -217,6 +221,38 @@ impl ReqwestHttpClient {
     /// timeouts.
     pub fn with_upload_stall_timeout(mut self, timeout: Duration) -> Self {
         self.upload_stall_timeout = timeout;
+        self
+    }
+
+    /// Override the request-body chunk size used to observe upload progress
+    /// (default 64 KiB). Smaller values provide finer progress granularity at
+    /// the cost of more body frames.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_bytes` is zero.
+    pub fn with_upload_chunk_bytes(mut self, chunk_bytes: usize) -> Self {
+        assert!(
+            chunk_bytes > 0,
+            "upload chunk size must be greater than zero"
+        );
+        self.upload_chunk_bytes = chunk_bytes;
+        self
+    }
+
+    /// Override how often the upload stall watchdog checks progress (default
+    /// 100ms). A stall may be detected up to roughly one poll interval after
+    /// `upload_stall_timeout` expires.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval` is zero.
+    pub fn with_upload_stall_poll_interval(mut self, interval: Duration) -> Self {
+        assert!(
+            !interval.is_zero(),
+            "upload stall poll interval must be greater than zero"
+        );
+        self.upload_stall_poll = interval;
         self
     }
 
@@ -297,6 +333,8 @@ impl HttpClient for ReqwestHttpClient {
         tracing::debug!(
             url.full = %url,
             upload_stall_timeout_ms = self.upload_stall_timeout.as_millis() as u64,
+            upload_chunk_bytes = self.upload_chunk_bytes,
+            upload_stall_poll_ms = self.upload_stall_poll.as_millis() as u64,
             first_chunk_timeout_ms = self.first_chunk_timeout.as_millis() as u64,
             chunk_timeout_ms = self.chunk_timeout.as_millis() as u64,
             body_timeout_ms = self.body_timeout.as_millis() as u64,
@@ -369,6 +407,7 @@ impl HttpClient for ReqwestHttpClient {
                 .body(reqwest::Body::wrap(ProgressBody {
                     remaining: body,
                     progress: progress.clone(),
+                    chunk_bytes: self.upload_chunk_bytes,
                 }));
             upload = Some(progress);
             tracing::trace!(
@@ -435,13 +474,14 @@ impl UploadProgress {
 
 /// Request body that reports upload progress to an [`UploadProgress`] handle.
 ///
-/// The body is handed to the transport in [`UPLOAD_CHUNK_BYTES`] chunks; each
-/// chunk the transport accepts counts as progress. The exact `size_hint`
-/// preserves Content-Length framing, so the wire format is identical to
-/// sending the buffered body directly.
+/// The body is handed to the transport in configurable chunks; each chunk
+/// the transport accepts counts as progress. The exact `size_hint` preserves
+/// Content-Length framing, so the wire format is identical to sending the
+/// buffered body directly.
 struct ProgressBody {
     remaining: bytes::Bytes,
     progress: Arc<UploadProgress>,
+    chunk_bytes: usize,
 }
 
 /// Owns one body chunk until Hyper has consumed it from its write buffer.
@@ -477,7 +517,7 @@ impl http_body::Body for ProgressBody {
         if this.remaining.is_empty() {
             return std::task::Poll::Ready(None);
         }
-        let take = this.remaining.len().min(UPLOAD_CHUNK_BYTES);
+        let take = this.remaining.len().min(this.chunk_bytes);
         let chunk = this.remaining.split_to(take);
         let tracked = bytes::Bytes::from_owner(TrackedUploadChunk {
             bytes: chunk,
@@ -507,6 +547,7 @@ async fn race_upload_stall<T>(
     send: impl std::future::Future<Output = T>,
     upload: Option<Arc<UploadProgress>>,
     stall_timeout: Duration,
+    poll_interval: Duration,
     url: &str,
 ) -> Result<T> {
     let Some(progress) = upload else {
@@ -516,7 +557,7 @@ async fn race_upload_stall<T>(
     loop {
         tokio::select! {
             out = &mut send => return Ok(out),
-            _ = tokio::time::sleep(UPLOAD_STALL_POLL) => {
+            _ = tokio::time::sleep(poll_interval) => {
                 if progress.is_complete() {
                     return Ok(send.await);
                 }
@@ -550,6 +591,7 @@ impl ReqwestHttpClient {
             req.timeout(total_timeout).send(),
             upload,
             self.upload_stall_timeout,
+            self.upload_stall_poll,
             url,
         )
         .await
@@ -637,23 +679,29 @@ impl ReqwestHttpClient {
                     );
                 })
         });
-        let resp = race_upload_stall(send, upload, self.upload_stall_timeout, url)
-            .await
-            .inspect_err(|e| {
-                tracing::error!(
-                    request_id = %request.id,
-                    url.full = %url,
-                    error = %e,
-                    "HTTP request upload stalled"
-                );
-            })?
-            .map_err(|_| {
-                crate::error::FusilladeError::FirstChunkTimeout(format!(
-                    "No response headers from {} within {}ms",
-                    url,
-                    self.first_chunk_timeout.as_millis()
-                ))
-            })??;
+        let resp = race_upload_stall(
+            send,
+            upload,
+            self.upload_stall_timeout,
+            self.upload_stall_poll,
+            url,
+        )
+        .await
+        .inspect_err(|e| {
+            tracing::error!(
+                request_id = %request.id,
+                url.full = %url,
+                error = %e,
+                "HTTP request upload stalled"
+            );
+        })?
+        .map_err(|_| {
+            crate::error::FusilladeError::FirstChunkTimeout(format!(
+                "No response headers from {} within {}ms",
+                url,
+                self.first_chunk_timeout.as_millis()
+            ))
+        })??;
 
         let status = resp.status().as_u16();
         let content_type = resp
@@ -1034,6 +1082,7 @@ mod tests {
         let mut body = std::pin::pin!(ProgressBody {
             remaining: bytes::Bytes::from_static(b"abc"),
             progress: progress.clone(),
+            chunk_bytes: DEFAULT_UPLOAD_CHUNK_BYTES,
         });
         let mut context = std::task::Context::from_waker(std::task::Waker::noop());
 
@@ -1047,6 +1096,97 @@ mod tests {
         assert_eq!(progress.sent_bytes(), 3);
     }
 
+    #[test]
+    fn configurable_upload_chunk_size_controls_progress_frames() {
+        use http_body::Body as _;
+
+        let progress = UploadProgress::new(6);
+        let mut body = std::pin::pin!(ProgressBody {
+            remaining: bytes::Bytes::from_static(b"abcdef"),
+            progress: progress.clone(),
+            chunk_bytes: 3,
+        });
+        let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+
+        let first = match body.as_mut().poll_frame(&mut context) {
+            std::task::Poll::Ready(Some(Ok(frame))) => frame.into_data().unwrap(),
+            other => panic!("expected first data frame, got {other:?}"),
+        };
+        assert_eq!(first.len(), 3);
+        drop(first);
+        assert_eq!(progress.sent_bytes(), 3);
+
+        let second = match body.as_mut().poll_frame(&mut context) {
+            std::task::Poll::Ready(Some(Ok(frame))) => frame.into_data().unwrap(),
+            other => panic!("expected second data frame, got {other:?}"),
+        };
+        assert_eq!(second.len(), 3);
+        drop(second);
+        assert_eq!(progress.sent_bytes(), 6);
+    }
+
+    #[test]
+    fn upload_watchdog_client_configuration_has_defaults_and_overrides() {
+        let client = ReqwestHttpClient::new(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            vec![],
+        );
+        assert_eq!(client.upload_chunk_bytes, 64 * 1024);
+        assert_eq!(client.upload_stall_poll, Duration::from_millis(100));
+
+        let client = client
+            .with_upload_chunk_bytes(8 * 1024)
+            .with_upload_stall_poll_interval(Duration::from_millis(25));
+        assert_eq!(client.upload_chunk_bytes, 8 * 1024);
+        assert_eq!(client.upload_stall_poll, Duration::from_millis(25));
+    }
+
+    #[test]
+    #[should_panic(expected = "upload chunk size must be greater than zero")]
+    fn zero_upload_chunk_size_is_rejected() {
+        let _ = ReqwestHttpClient::new(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            vec![],
+        )
+        .with_upload_chunk_bytes(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "upload stall poll interval must be greater than zero")]
+    fn zero_upload_stall_poll_interval_is_rejected() {
+        let _ = ReqwestHttpClient::new(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            vec![],
+        )
+        .with_upload_stall_poll_interval(Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn configurable_upload_stall_poll_controls_first_check() {
+        let result = tokio::time::timeout(
+            Duration::from_millis(250),
+            race_upload_stall(
+                std::future::pending::<()>(),
+                Some(UploadProgress::new(1)),
+                Duration::from_millis(1),
+                Duration::from_secs(5),
+                "http://example.test",
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "watchdog checked before the configured poll interval"
+        );
+    }
+
     #[tokio::test]
     async fn upload_watchdog_aborts_when_progress_stops() {
         let stall_timeout = Duration::from_millis(250);
@@ -1058,6 +1198,7 @@ mod tests {
                 std::future::pending::<()>(),
                 Some(progress),
                 stall_timeout,
+                DEFAULT_UPLOAD_STALL_POLL,
                 "http://example.test",
             ),
         )
@@ -1083,6 +1224,7 @@ mod tests {
                 async move { send_complete_rx.await.unwrap() },
                 Some(watchdog_progress),
                 stall_timeout,
+                DEFAULT_UPLOAD_STALL_POLL,
                 "http://example.test",
             )
             .await

--- a/src/http.rs
+++ b/src/http.rs
@@ -183,7 +183,7 @@ pub struct ReqwestHttpClient {
 }
 
 /// Default cap on how long a request body upload may make no progress.
-const DEFAULT_UPLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const DEFAULT_UPLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Request bodies are handed to the transport in chunks of this size so the
 /// upload watchdog can observe progress.
@@ -296,6 +296,7 @@ impl HttpClient for ReqwestHttpClient {
 
         tracing::debug!(
             url.full = %url,
+            upload_stall_timeout_ms = self.upload_stall_timeout.as_millis() as u64,
             first_chunk_timeout_ms = self.first_chunk_timeout.as_millis() as u64,
             chunk_timeout_ms = self.chunk_timeout.as_millis() as u64,
             body_timeout_ms = self.body_timeout.as_millis() as u64,

--- a/src/http.rs
+++ b/src/http.rs
@@ -397,7 +397,6 @@ struct UploadProgress {
     last_progress_ms: std::sync::atomic::AtomicU64,
     sent: std::sync::atomic::AtomicU64,
     total: u64,
-    handed_off: std::sync::atomic::AtomicBool,
 }
 
 impl UploadProgress {
@@ -407,7 +406,6 @@ impl UploadProgress {
             last_progress_ms: std::sync::atomic::AtomicU64::new(0),
             sent: std::sync::atomic::AtomicU64::new(0),
             total,
-            handed_off: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -418,13 +416,8 @@ impl UploadProgress {
             .store(self.started.elapsed().as_millis() as u64, Ordering::Relaxed);
     }
 
-    fn finish(&self) {
-        self.handed_off
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn is_handed_off(&self) -> bool {
-        self.handed_off.load(std::sync::atomic::Ordering::Relaxed)
+    fn is_complete(&self) -> bool {
+        self.sent_bytes() >= self.total
     }
 
     fn stalled_for(&self) -> Duration {
@@ -451,6 +444,26 @@ struct ProgressBody {
     progress: Arc<UploadProgress>,
 }
 
+/// Owns one body chunk until Hyper has consumed it from its write buffer.
+/// Dropping the last `Bytes` reference is the closest per-request signal
+/// reqwest exposes that the transport writer accepted the complete chunk.
+struct TrackedUploadChunk {
+    bytes: bytes::Bytes,
+    progress: Arc<UploadProgress>,
+}
+
+impl AsRef<[u8]> for TrackedUploadChunk {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl Drop for TrackedUploadChunk {
+    fn drop(&mut self) {
+        self.progress.record(self.bytes.len());
+    }
+}
+
 impl http_body::Body for ProgressBody {
     type Data = bytes::Bytes;
     type Error = std::convert::Infallible;
@@ -462,19 +475,15 @@ impl http_body::Body for ProgressBody {
     {
         let this = self.get_mut();
         if this.remaining.is_empty() {
-            this.progress.finish();
             return std::task::Poll::Ready(None);
         }
         let take = this.remaining.len().min(UPLOAD_CHUNK_BYTES);
         let chunk = this.remaining.split_to(take);
-        this.progress.record(take);
-        if this.remaining.is_empty() {
-            // The final chunk is now owned by the transport; from here on the
-            // request is waiting on the upstream, which the response timeouts
-            // govern.
-            this.progress.finish();
-        }
-        std::task::Poll::Ready(Some(Ok(http_body::Frame::data(chunk))))
+        let tracked = bytes::Bytes::from_owner(TrackedUploadChunk {
+            bytes: chunk,
+            progress: this.progress.clone(),
+        });
+        std::task::Poll::Ready(Some(Ok(http_body::Frame::data(tracked))))
     }
 
     fn is_end_stream(&self) -> bool {
@@ -488,11 +497,12 @@ impl http_body::Body for ProgressBody {
 
 /// Race `send` against an upload stall watchdog.
 ///
-/// The watchdog fires only while the body is still being handed to the
-/// transport: if no chunk is accepted for `stall_timeout`, the attempt is
-/// aborted so the daemon's retry machinery can dispatch a fresh one. Once the
-/// body is fully handed off the watchdog disarms and `send`'s own timeouts
-/// take over. Requests without a body (`upload` is `None`) are unaffected.
+/// The watchdog fires only while Hyper still owns queued request-body bytes:
+/// if the transport writer consumes no complete chunk for `stall_timeout`,
+/// the attempt is aborted so the daemon's retry machinery can dispatch a
+/// fresh one. Once all chunks have been consumed the watchdog disarms and
+/// `send`'s own timeouts take over. Requests without a body (`upload` is
+/// `None`) are unaffected.
 async fn race_upload_stall<T>(
     send: impl std::future::Future<Output = T>,
     upload: Option<Arc<UploadProgress>>,
@@ -507,12 +517,12 @@ async fn race_upload_stall<T>(
         tokio::select! {
             out = &mut send => return Ok(out),
             _ = tokio::time::sleep(UPLOAD_STALL_POLL) => {
-                if progress.is_handed_off() {
+                if progress.is_complete() {
                     return Ok(send.await);
                 }
                 if progress.stalled_for() >= stall_timeout {
                     return Err(crate::error::FusilladeError::UploadStallTimeout(format!(
-                        "request upload to {} stalled: {} of {} bytes handed to the transport, no progress for {}ms",
+                        "request upload to {} stalled: {} of {} bytes accepted by the transport writer, no progress for {}ms",
                         url,
                         progress.sent_bytes(),
                         progress.total,
@@ -1015,6 +1025,27 @@ impl Drop for InFlightGuard {
 mod tests {
     use super::*;
     use crate::request::RequestId;
+
+    #[test]
+    fn upload_completes_only_after_transport_releases_final_chunk() {
+        use http_body::Body as _;
+
+        let progress = UploadProgress::new(3);
+        let mut body = std::pin::pin!(ProgressBody {
+            remaining: bytes::Bytes::from_static(b"abc"),
+            progress: progress.clone(),
+        });
+        let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+
+        let frame = match body.as_mut().poll_frame(&mut context) {
+            std::task::Poll::Ready(Some(Ok(frame))) => frame.into_data().unwrap(),
+            other => panic!("expected a data frame, got {other:?}"),
+        };
+
+        assert_eq!(progress.sent_bytes(), 0);
+        drop(frame);
+        assert_eq!(progress.sent_bytes(), 3);
+    }
 
     #[tokio::test]
     async fn test_mock_client_basic() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1048,6 +1048,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn upload_watchdog_aborts_when_progress_stops() {
+        let stall_timeout = Duration::from_millis(250);
+        let progress = UploadProgress::new(1);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            race_upload_stall(
+                std::future::pending::<()>(),
+                Some(progress),
+                stall_timeout,
+                "http://example.test",
+            ),
+        )
+        .await
+        .expect("watchdog did not enforce the stall timeout")
+        .unwrap_err();
+
+        assert!(matches!(
+            result,
+            crate::error::FusilladeError::UploadStallTimeout(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn upload_watchdog_allows_progress_across_multiple_stall_windows() {
+        const PROGRESS_STEPS: u64 = 24;
+        let stall_timeout = Duration::from_millis(250);
+        let progress = UploadProgress::new(PROGRESS_STEPS);
+        let watchdog_progress = progress.clone();
+        let (send_complete_tx, send_complete_rx) = tokio::sync::oneshot::channel();
+        let watchdog = tokio::spawn(async move {
+            race_upload_stall(
+                async move { send_complete_rx.await.unwrap() },
+                Some(watchdog_progress),
+                stall_timeout,
+                "http://example.test",
+            )
+            .await
+        });
+
+        let started = std::time::Instant::now();
+        let mut pacing = tokio::time::interval(Duration::from_millis(25));
+        pacing.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        for _ in 0..PROGRESS_STEPS {
+            pacing.tick().await;
+            progress.record(1);
+            assert!(
+                !watchdog.is_finished(),
+                "watchdog aborted despite continuing upload progress"
+            );
+        }
+        assert!(
+            started.elapsed() > stall_timeout * 2,
+            "test did not span multiple complete stall windows"
+        );
+
+        send_complete_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), watchdog)
+            .await
+            .expect("watchdog did not finish after upload and send completion")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_mock_client_basic() {
         let mock = MockHttpClient::new();
         mock.add_response(

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -62,7 +62,9 @@ where
                 Duration::from_millis(config.body_timeout_ms),
                 config.streamable_endpoints.clone(),
             )
-            .with_upload_stall_timeout(Duration::from_millis(config.upload_stall_timeout_ms)),
+            .with_upload_stall_timeout(Duration::from_millis(config.upload_stall_timeout_ms))
+            .with_upload_chunk_bytes(config.upload_chunk_bytes)
+            .with_upload_stall_poll_interval(Duration::from_millis(config.upload_stall_poll_ms)),
         );
         Self::new(storage, http_client, config)
     }

--- a/src/manager/postgres.rs
+++ b/src/manager/postgres.rs
@@ -55,12 +55,15 @@ where
     /// Build a PostgreSQL daemon runtime from an existing Arsenal store and
     /// the default Reqwest HTTP client.
     pub fn from_store(storage: Arc<PostgresStore<P>>, config: DaemonConfig) -> Self {
-        let http_client = Arc::new(ReqwestHttpClient::new(
-            Duration::from_millis(config.first_chunk_timeout_ms),
-            Duration::from_millis(config.chunk_timeout_ms),
-            Duration::from_millis(config.body_timeout_ms),
-            config.streamable_endpoints.clone(),
-        ));
+        let http_client = Arc::new(
+            ReqwestHttpClient::new(
+                Duration::from_millis(config.first_chunk_timeout_ms),
+                Duration::from_millis(config.chunk_timeout_ms),
+                Duration::from_millis(config.body_timeout_ms),
+                config.streamable_endpoints.clone(),
+            )
+            .with_upload_stall_timeout(Duration::from_millis(config.upload_stall_timeout_ms)),
+        );
         Self::new(storage, http_client, config)
     }
 

--- a/tests/upload_stall.rs
+++ b/tests/upload_stall.rs
@@ -101,7 +101,7 @@ async fn upload_stall_aborts_after_stall_timeout() {
         stream.read_exact(&mut first).await.unwrap();
         // Stop reading but keep the connection open: the client's kernel
         // buffers fill and the upload can make no further progress.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        std::future::pending::<()>().await;
         drop(stream);
     });
 
@@ -138,13 +138,13 @@ async fn slow_but_progressing_upload_is_not_killed() {
         assert!(headers.to_lowercase().contains("content-length"));
         let mut remaining = body_len;
         let mut chunk = vec![0u8; 1024 * 1024];
+        let mut pacing = tokio::time::interval(Duration::from_millis(100));
+        pacing.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         while remaining > 0 {
+            pacing.tick().await;
             let take = remaining.min(chunk.len());
             stream.read_exact(&mut chunk[..take]).await.unwrap();
             remaining -= take;
-            // Drain slowly: total upload takes several multiples of the
-            // stall timeout, but progress never pauses long enough to trip it.
-            tokio::time::sleep(Duration::from_millis(100)).await;
         }
         stream
             .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
@@ -156,6 +156,56 @@ async fn slow_but_progressing_upload_is_not_killed() {
     let response = client(Duration::from_millis(500))
         .execute(&request, "test-key")
         .await
+        .unwrap();
+    assert_eq!(response.status, 200);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn completed_upload_can_wait_longer_than_stall_timeout_for_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body_len = 128 * 1024;
+    let (body_read_tx, body_read_rx) = tokio::sync::oneshot::channel();
+    let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let headers = read_headers(&mut stream).await;
+        assert!(headers.to_lowercase().contains("content-length"));
+        let mut received = vec![0u8; body_len];
+        stream.read_exact(&mut received).await.unwrap();
+        body_read_tx.send(()).unwrap();
+        respond_rx.await.unwrap();
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .unwrap();
+    });
+
+    let request = test_request(format!("http://{addr}"), "x".repeat(body_len));
+    let mut client_task = tokio::spawn(async move {
+        client(Duration::from_millis(100))
+            .execute(&request, "test-key")
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), body_read_rx)
+        .await
+        .expect("server did not receive the complete body")
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(300), &mut client_task)
+            .await
+            .is_err(),
+        "request completed while the server was deliberately withholding response headers"
+    );
+
+    respond_tx.send(()).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(5), client_task)
+        .await
+        .expect("request did not complete after response headers were released")
+        .unwrap()
         .unwrap();
     assert_eq!(response.status, 200);
     server.await.unwrap();

--- a/tests/upload_stall.rs
+++ b/tests/upload_stall.rs
@@ -1,0 +1,162 @@
+//! Integration tests for the request upload stall watchdog.
+//!
+//! These use raw TCP servers (no database) to control exactly how much of the
+//! request the "upstream" reads, exercising the send phase of
+//! `ReqwestHttpClient` in ways a well-behaved HTTP mock cannot.
+
+use std::time::{Duration, Instant};
+
+use fusillade::batch::{BatchId, TemplateId};
+use fusillade::http::{HttpClient, ReqwestHttpClient};
+use fusillade::{FusilladeError, RequestData, RequestId};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn test_request(endpoint: String, body: String) -> RequestData {
+    RequestData {
+        id: RequestId::from(uuid::Uuid::new_v4()),
+        batch_id: Some(BatchId::from(uuid::Uuid::new_v4())),
+        template_id: TemplateId::from(uuid::Uuid::new_v4()),
+        custom_id: None,
+        endpoint,
+        method: "POST".to_string(),
+        path: "/v1/test".to_string(),
+        body,
+        model: "test-model".to_string(),
+        api_key: "test-key".to_string(),
+        created_by: String::new(),
+        batch_metadata: std::collections::HashMap::new(),
+    }
+}
+
+fn client(stall: Duration) -> ReqwestHttpClient {
+    ReqwestHttpClient::new(
+        Duration::from_secs(10),
+        Duration::from_secs(10),
+        Duration::from_secs(10),
+        vec![],
+    )
+    .with_upload_stall_timeout(stall)
+}
+
+async fn read_headers(stream: &mut tokio::net::TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    while !buf.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).await.unwrap();
+        buf.push(byte[0]);
+    }
+    String::from_utf8(buf).unwrap()
+}
+
+#[tokio::test]
+async fn healthy_upload_preserves_content_length_framing() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = "x".repeat(200 * 1024);
+    let body_len = body.len();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let headers = read_headers(&mut stream).await;
+        let lower = headers.to_lowercase();
+        assert!(
+            lower.contains(&format!("content-length: {body_len}")),
+            "expected exact content-length header, got: {headers}"
+        );
+        assert!(
+            !lower.contains("transfer-encoding"),
+            "body must not switch to chunked framing, got: {headers}"
+        );
+        let mut received = vec![0u8; body_len];
+        stream.read_exact(&mut received).await.unwrap();
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .unwrap();
+        received
+    });
+
+    let request = test_request(format!("http://{addr}"), body.clone());
+    let response = client(Duration::from_secs(5))
+        .execute(&request, "test-key")
+        .await
+        .unwrap();
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, "ok");
+
+    let received = server.await.unwrap();
+    assert_eq!(received.len(), body_len);
+    assert_eq!(received, body.into_bytes());
+}
+
+#[tokio::test]
+async fn upload_stall_aborts_after_stall_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut first = vec![0u8; 1024];
+        stream.read_exact(&mut first).await.unwrap();
+        // Stop reading but keep the connection open: the client's kernel
+        // buffers fill and the upload can make no further progress.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        drop(stream);
+    });
+
+    let request = test_request(format!("http://{addr}"), "x".repeat(8 * 1024 * 1024));
+    let started = Instant::now();
+    let error = client(Duration::from_millis(500))
+        .execute(&request, "test-key")
+        .await
+        .unwrap_err();
+
+    match error {
+        FusilladeError::UploadStallTimeout(message) => {
+            assert!(message.contains("stalled"), "unexpected message: {message}");
+        }
+        other => panic!("expected UploadStallTimeout, got: {other:?}"),
+    }
+    assert!(
+        started.elapsed() < Duration::from_secs(15),
+        "stall abort took {:?}",
+        started.elapsed()
+    );
+    server.abort();
+}
+
+#[tokio::test]
+async fn slow_but_progressing_upload_is_not_killed() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body_len = 16 * 1024 * 1024;
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let headers = read_headers(&mut stream).await;
+        assert!(headers.to_lowercase().contains("content-length"));
+        let mut remaining = body_len;
+        let mut chunk = vec![0u8; 1024 * 1024];
+        while remaining > 0 {
+            let take = remaining.min(chunk.len());
+            stream.read_exact(&mut chunk[..take]).await.unwrap();
+            remaining -= take;
+            // Drain slowly: total upload takes several multiples of the
+            // stall timeout, but progress never pauses long enough to trip it.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .unwrap();
+    });
+
+    let request = test_request(format!("http://{addr}"), "x".repeat(body_len));
+    let response = client(Duration::from_millis(500))
+        .execute(&request, "test-key")
+        .await
+        .unwrap();
+    assert_eq!(response.status, 200);
+    server.await.unwrap();
+}

--- a/tests/upload_stall.rs
+++ b/tests/upload_stall.rs
@@ -1,8 +1,9 @@
 //! Integration tests for the request upload stall watchdog.
 //!
-//! These use raw TCP servers (no database) to control exactly how much of the
-//! request the "upstream" reads, exercising the send phase of
-//! `ReqwestHttpClient` in ways a well-behaved HTTP mock cannot.
+//! These use raw TCP servers (no database) to verify request framing and the
+//! boundary between upload completion and response waiting. Watchdog timing
+//! is covered by controlled unit tests in `http.rs`, independent of platform
+//! TCP buffer sizes.
 
 use std::time::{Duration, Instant};
 
@@ -10,7 +11,9 @@ use fusillade::batch::{BatchId, TemplateId};
 use fusillade::http::{HttpClient, ReqwestHttpClient};
 use fusillade::{FusilladeError, RequestData, RequestId};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpSocket};
+
+const TEST_RECEIVE_BUFFER_BYTES: u32 = 16 * 1024;
 
 fn test_request(endpoint: String, body: String) -> RequestData {
     RequestData {
@@ -47,6 +50,20 @@ async fn read_headers(stream: &mut tokio::net::TcpStream) -> String {
         buf.push(byte[0]);
     }
     String::from_utf8(buf).unwrap()
+}
+
+fn backpressured_listener() -> TcpListener {
+    let socket = TcpSocket::new_v4().unwrap();
+    socket
+        .set_recv_buffer_size(TEST_RECEIVE_BUFFER_BYTES)
+        .unwrap();
+    let effective_size = socket.recv_buffer_size().unwrap();
+    assert!(
+        effective_size < 1024 * 1024,
+        "test receive buffer is too large to enforce backpressure: {effective_size} bytes"
+    );
+    socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    socket.listen(1).unwrap()
 }
 
 #[tokio::test]
@@ -92,15 +109,15 @@ async fn healthy_upload_preserves_content_length_framing() {
 
 #[tokio::test]
 async fn upload_stall_aborts_after_stall_timeout() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = backpressured_listener();
     let addr = listener.local_addr().unwrap();
 
     let server = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
         let mut first = vec![0u8; 1024];
         stream.read_exact(&mut first).await.unwrap();
-        // Stop reading but keep the connection open: the client's kernel
-        // buffers fill and the upload can make no further progress.
+        // Stop reading but keep the connection open. The deliberately small
+        // receive buffer ensures the client's upload cannot finish locally.
         std::future::pending::<()>().await;
         drop(stream);
     });
@@ -128,9 +145,10 @@ async fn upload_stall_aborts_after_stall_timeout() {
 
 #[tokio::test]
 async fn slow_but_progressing_upload_is_not_killed() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = backpressured_listener();
     let addr = listener.local_addr().unwrap();
     let body_len = 16 * 1024 * 1024;
+    let stall_timeout = Duration::from_millis(500);
 
     let server = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
@@ -153,11 +171,16 @@ async fn slow_but_progressing_upload_is_not_killed() {
     });
 
     let request = test_request(format!("http://{addr}"), "x".repeat(body_len));
-    let response = client(Duration::from_millis(500))
+    let started = Instant::now();
+    let response = client(stall_timeout)
         .execute(&request, "test-key")
         .await
         .unwrap();
     assert_eq!(response.status, 200);
+    assert!(
+        started.elapsed() > stall_timeout * 2,
+        "test did not span multiple complete stall windows"
+    );
     server.await.unwrap();
 }
 


### PR DESCRIPTION
## Motivation

An HTTP dispatch can rarely stop making progress while sending its request body. The connection may remain open, but the transport stops accepting additional body bytes and the attempt does not complete.

`reqwest::RequestBuilder::send()` covers connection setup, body upload, and waiting for response headers as one future. The existing `first_chunk_timeout` must often allow long upstream queue and response-start times, so it is too broad to detect an upload that should normally complete quickly.

This change adds progress-based detection for the upload phase. A stalled attempt is aborted and passed to the existing retry machinery, while a slow upload that continues making progress is left alone.

## Why a separate progress watchdog

- A short timeout around all of `send()` would reject legitimate requests that wait a long time for the upstream to begin responding.
- A large timeout around all of `send()` allows a stalled upload to consume the response-start budget.
- A fixed total upload deadline would penalize large bodies or slow links even when bytes are still moving.
- Upload progress provides the useful signal: stalled uploads stop advancing; healthy slow uploads continue advancing.

## Mechanism

- `ProgressBody` supplies the request body in tracked frames whose size is configurable and defaults to 64 KiB.
- Progress is recorded when Hyper releases a frame after consuming it from the transport write buffer, rather than when the body is merely polled.
- The body keeps an exact size hint, preserving `Content-Length` framing.
- `race_upload_stall()` races `send()` against a watchdog. If no upload progress occurs for `upload_stall_timeout`, the attempt fails with `FusilladeError::UploadStallTimeout`.
- The watchdog polling cadence is configurable and defaults to 100 milliseconds.
- Once the transport writer has consumed the complete body, the upload watchdog disarms and the existing response timeouts continue to govern the request.
- `UploadStallTimeout` maps to `FailureReason::Timeout`, so the normal retry policy can dispatch another attempt.
- Requests without bodies are unaffected.

## Timeout configuration

The daemon exposes the upload watchdog controls beside the existing HTTP timeout settings on `DaemonConfig`:

```rust
let config = DaemonConfig {
    upload_stall_timeout_ms: 60_000,
    upload_chunk_bytes: 64 * 1024,
    upload_stall_poll_ms: 100,
    first_chunk_timeout_ms: 30 * 60_000,
    chunk_timeout_ms: 5 * 60_000,
    body_timeout_ms: 2 * 60 * 60_000,
    ..DaemonConfig::default()
};
```

The values above are illustrative. Set them according to the expected upload and response characteristics:

- `upload_stall_timeout_ms` is the maximum idle period with no outbound body progress. It defaults to 60 seconds and should be lower than `first_chunk_timeout_ms`. Both clocks can run during `send()`, so whichever expires first determines the reported timeout.
- `upload_chunk_bytes` is the progress granularity and defaults to 65,536 bytes. Smaller values observe progress more finely but create more body frames; larger values reduce framing overhead but require a complete larger unit to be released before progress is recorded. It must be greater than zero.
- `upload_stall_poll_ms` controls how often progress is checked and defaults to 100 milliseconds. Keep it well below `upload_stall_timeout_ms`; detection may occur up to roughly one poll interval after the stall timeout expires. It must be greater than zero.
- `first_chunk_timeout_ms` covers connection setup, request upload, response headers, and the first streaming event. Size it for the longest legitimate wait before the upstream begins responding.
- `chunk_timeout_ms` is the maximum idle period between subsequent SSE events. It applies only to streaming endpoints and starts after the first event arrives.
- `body_timeout_ms` bounds total response-body collection. For streaming responses it runs alongside `chunk_timeout_ms`, so either the total-duration limit or the per-event idle limit may end the attempt first.

For non-streaming requests, `chunk_timeout_ms` is unused and the existing client behaviour combines `first_chunk_timeout_ms + body_timeout_ms` into one overall request timeout. The upload-stall watchdog applies to both streaming and non-streaming requests while the transport writer is consuming their bodies.

Direct users of `ReqwestHttpClient` can override the same controls with:

```rust
let client = ReqwestHttpClient::new(/* existing timeout arguments */)
    .with_upload_stall_timeout(Duration::from_secs(60))
    .with_upload_chunk_bytes(64 * 1024)
    .with_upload_stall_poll_interval(Duration::from_millis(100));
```

## Tests

- Configuration tests cover defaults, older serialized configurations, explicit values, and invalid zero values.
- Controlled watchdog tests verify that idle uploads abort, custom polling is applied, and continuing progress remains alive across multiple complete stall windows.
- Body tests verify that configured chunk sizes control progress granularity.
- Raw TCP stall tests use an explicitly bounded receive buffer to enforce end-to-end backpressure.
- A completed upload may wait longer than the upload-stall timeout for response headers.
- Yielding the final body frame does not mark the upload complete until the transport releases it.
- A healthy round trip preserves the exact `Content-Length`, does not switch to `Transfer-Encoding`, and receives a byte-identical body.
