### PR TITLE
fix: synchronize workspace release dependencies

### DIFF
--- a/.github/scripts/sync-release-dependencies.py
+++ b/.github/scripts/sync-release-dependencies.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Synchronize workspace dependency requirements across release majors."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def major(version: str) -> str:
+    return version.split(".", 1)[0]
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    parts = [int(part) for part in version.split(".")]
+    return tuple((parts + [0, 0])[:3])
+
+
+def requirement_accepts(requirement: str, tracked_version: str) -> bool:
+    if major(requirement.lstrip("^~=")) == major(tracked_version):
+        return True
+
+    clauses = [clause.strip() for clause in requirement.split(",")]
+    tracked = parse_version(tracked_version)
+    comparisons = {
+        ">=": lambda candidate, bound: candidate >= bound,
+        "<=": lambda candidate, bound: candidate <= bound,
+        ">": lambda candidate, bound: candidate > bound,
+        "<": lambda candidate, bound: candidate < bound,
+        "=": lambda candidate, bound: candidate == bound,
+    }
+
+    for clause in clauses:
+        match = re.fullmatch(r"(>=|<=|>|<|=)\s*(\d+(?:\.\d+){0,2})", clause)
+        if not match:
+            return False
+        if not comparisons[match.group(1)](tracked, parse_version(match.group(2))):
+            return False
+    return True
+
+
+def sync_dependency(
+    manifest: Path, dependency: str, tracked_version: str, check: bool
+) -> bool:
+    text = manifest.read_text()
+    pattern = re.compile(
+        rf'(?m)^(\s*{re.escape(dependency)}\s*=\s*'
+        rf'(?:\{{[^\n}}]*?\bversion\s*=\s*)?")([^\"]+)(")'
+    )
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise SystemExit(
+            f"expected exactly one {dependency} requirement in {manifest}, "
+            f"found {len(matches)}"
+        )
+
+    match = matches[0]
+    requirement = match.group(2)
+    if requirement_accepts(requirement, tracked_version):
+        return False
+
+    if check:
+        print(
+            f"{manifest} requires {dependency} {requirement}, but "
+            f"release-please tracks {tracked_version}",
+            file=sys.stderr,
+        )
+        return True
+
+    updated = text[: match.start(2)] + tracked_version + text[match.end(2) :]
+    manifest.write_text(updated)
+    print(f"Updated {manifest}: {dependency} {requirement} -> {tracked_version}")
+    return True
+
+
+def main() -> None:
+    arguments = sys.argv[1:]
+    check = "--check" in arguments
+    arguments = [argument for argument in arguments if argument != "--check"]
+    if len(arguments) > 1:
+        raise SystemExit("usage: sync-release-dependencies.py [--check] [repo]")
+    repo_root = Path(arguments[0]).resolve() if arguments else Path.cwd()
+    versions = json.loads(
+        (repo_root / ".release-please-manifest.json").read_text()
+    )
+
+    dependencies = (
+        (repo_root / "Cargo.toml", "fusillade-core", "crates/fusillade-core"),
+        (
+            repo_root / "Cargo.toml",
+            "fusillade-arsenal",
+            "crates/fusillade-arsenal",
+        ),
+        (
+            repo_root / "crates/fusillade-arsenal/Cargo.toml",
+            "fusillade-core",
+            "crates/fusillade-core",
+        ),
+    )
+
+    changes_needed = False
+    for manifest, dependency, tracked_path in dependencies:
+        tracked_version = versions.get(tracked_path)
+        if not tracked_version:
+            raise SystemExit(
+                f"could not find tracked version for {tracked_path} in "
+                ".release-please-manifest.json"
+            )
+        changes_needed |= sync_dependency(
+            manifest, dependency, tracked_version, check
+        )
+
+    if check and changes_needed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-arsenal-sqlx-cache.sh
+++ b/.github/scripts/test-arsenal-sqlx-cache.sh
@@ -30,9 +30,23 @@ fi
 # Skipping is safe: cargo publish runs the identical verify build at publish
 # time, gated behind wait_for_crate_version in publish-crate.sh, so nothing
 # ships unverified.
-core_version="$(sed -n 's/^fusillade-core = { version = "\([^"]*\)".*/\1/p' crates/fusillade-arsenal/Cargo.toml | head -n 1)"
+core_requirement="$(sed -n 's/^fusillade-core = { version = "\([^"]*\)".*/\1/p' crates/fusillade-arsenal/Cargo.toml | head -n 1)"
+if [[ -z "${core_requirement}" ]]; then
+  echo "Could not determine the fusillade-core requirement from crates/fusillade-arsenal/Cargo.toml." >&2
+  exit 1
+fi
+
+# A requirement may deliberately span multiple compatible majors, so query the
+# concrete version tracked for release instead of treating the requirement as
+# a crates.io version URL.
+core_version="$(awk '
+  $1 == "\"crates/fusillade-core\":" {
+    gsub(/[",]/, "", $2)
+    print $2
+  }
+' .release-please-manifest.json)"
 if [[ -z "${core_version}" ]]; then
-  echo "Could not determine the fusillade-core version from crates/fusillade-arsenal/Cargo.toml." >&2
+  echo "Could not determine the tracked fusillade-core version." >&2
   exit 1
 fi
 

--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -65,6 +65,11 @@ if grep -q '"always-link-local"[[:space:]]*:[[:space:]]*true' release-please-con
   exit 1
 fi
 
+if ! grep -q 'sync-release-dependencies.py' .github/workflows/release-please.yaml; then
+  echo "release-please must synchronize workspace dependency majors on its release PR" >&2
+  exit 1
+fi
+
 manifest_version() {
   sed -n 's/^version = "\([^"]*\)".*/\1/p' "$1" | head -n 1
 }
@@ -105,45 +110,6 @@ for package_path in crates/fusillade-core crates/fusillade-arsenal; do
   fi
 done
 
-# Internal dependency requirements must stay resolvable against the versions
-# release-please tracks. With the cargo-workspace plugin removed (it kept
-# stamping unreleased crates with other crates' versions — see #345 and #350),
-# nothing rewrites these requirement strings automatically. That is fine for
-# minor/patch releases: `version = "1.1.1"` means ^1.1.1 and resolves newer
-# 1.x automatically. It is NOT fine across a MAJOR bump — a stale ^1.x
-# requirement would make a published dependent silently build against the old
-# major. This check forces the manual requirement bump into the same release.
-dependency_requirement() {
-  local manifest="$1" crate="$2"
-  # Tolerant of indentation and inline-table field order (path before
-  # version, etc.); still anchored so other crate names can't match.
-  sed -n "s/^[[:space:]]*${crate}[[:space:]]*=.*version[[:space:]]*=[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$manifest" | head -n 1
-}
-
-major_of() {
-  echo "${1%%.*}"
-}
-
-while read -r manifest crate tracked_path; do
-  requirement="$(dependency_requirement "$manifest" "$crate")"
-  tracked="$(release_manifest_version "$tracked_path")"
-
-  if [[ -z "$tracked" ]]; then
-    echo "could not find tracked version for ${tracked_path} in .release-please-manifest.json" >&2
-    exit 1
-  fi
-
-  if [[ -z "$requirement" ]]; then
-    echo "could not find internal dependency ${crate} in ${manifest}" >&2
-    exit 1
-  fi
-
-  if [[ "$(major_of "$requirement")" != "$(major_of "$tracked")" ]]; then
-    echo "${manifest} requires ${crate} ^${requirement}, but release-please tracks ${tracked}: bump the requirement in the same release as the major bump" >&2
-    exit 1
-  fi
-done <<'DEPS'
-Cargo.toml fusillade-core crates/fusillade-core
-Cargo.toml fusillade-arsenal crates/fusillade-arsenal
-crates/fusillade-arsenal/Cargo.toml fusillade-core crates/fusillade-core
-DEPS
+# Internal dependency requirements must resolve the versions release-please
+# tracks. The synchronizer performs the same check before updating release PRs.
+python3 .github/scripts/sync-release-dependencies.py --check

--- a/.github/scripts/test-sync-release-dependencies.sh
+++ b/.github/scripts/test-sync-release-dependencies.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/crates/fusillade-core" "$fixture/crates/fusillade-arsenal"
+
+cat >"$fixture/.release-please-manifest.json" <<'JSON'
+{
+  ".": "23.0.0",
+  "crates/fusillade-core": "3.0.0",
+  "crates/fusillade-arsenal": "2.1.2"
+}
+JSON
+
+cat >"$fixture/Cargo.toml" <<'TOML'
+[package]
+name = "fusillade"
+version = "23.0.0"
+
+[dependencies]
+fusillade-core = { path = "crates/fusillade-core", version = "2.1.0" }
+fusillade-arsenal = { version = "2.0.0", path = "crates/fusillade-arsenal" }
+TOML
+
+cat >"$fixture/crates/fusillade-core/Cargo.toml" <<'TOML'
+[package]
+name = "fusillade-core"
+version = "3.0.0"
+TOML
+
+cat >"$fixture/crates/fusillade-arsenal/Cargo.toml" <<'TOML'
+[package]
+name = "fusillade-arsenal"
+version = "2.1.2"
+
+[dependencies]
+fusillade-core = { version = ">=2.1.0, <4.0.0", path = "../fusillade-core" }
+TOML
+
+if python3 "$repo_root/.github/scripts/sync-release-dependencies.py" \
+  --check "$fixture"; then
+  echo "check mode should reject stale dependency requirements" >&2
+  exit 1
+fi
+
+python3 "$repo_root/.github/scripts/sync-release-dependencies.py" "$fixture"
+
+grep -Fq 'fusillade-core = { path = "crates/fusillade-core", version = "3.0.0" }' \
+  "$fixture/Cargo.toml"
+grep -Fq 'fusillade-arsenal = { version = "2.0.0", path = "crates/fusillade-arsenal" }' \
+  "$fixture/Cargo.toml"
+grep -Fq 'fusillade-core = { version = ">=2.1.0, <4.0.0", path = "../fusillade-core" }' \
+  "$fixture/crates/fusillade-arsenal/Cargo.toml"
+
+python3 "$repo_root/.github/scripts/sync-release-dependencies.py" \
+  --check "$fixture"
+
+cp "$fixture/Cargo.toml" "$fixture/Cargo.toml.once"
+cp "$fixture/crates/fusillade-arsenal/Cargo.toml" \
+  "$fixture/crates/fusillade-arsenal/Cargo.toml.once"
+
+python3 "$repo_root/.github/scripts/sync-release-dependencies.py" "$fixture"
+
+diff -u "$fixture/Cargo.toml.once" "$fixture/Cargo.toml"
+diff -u "$fixture/crates/fusillade-arsenal/Cargo.toml.once" \
+  "$fixture/crates/fusillade-arsenal/Cargo.toml"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,7 +15,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve release PR branch
+        id: release-pr
+        env:
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: |
+          if [[ -z "$RELEASE_PRS" ]]; then
+            echo "branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "branch=$(jq -r '.[0].headBranchName // empty' <<<"$RELEASE_PRS")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR
+        if: steps.release-pr.outputs.branch != ''
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          ref: ${{ steps.release-pr.outputs.branch }}
+
+      - name: Synchronize workspace dependency majors
+        if: steps.release-pr.outputs.branch != ''
+        run: |
+          python3 .github/scripts/sync-release-dependencies.py
+
+          if git diff --quiet -- Cargo.toml crates/fusillade-arsenal/Cargo.toml; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml crates/fusillade-arsenal/Cargo.toml
+          git commit -m "chore: sync workspace release dependencies"
+          git push origin HEAD:${{ steps.release-pr.outputs.branch }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "fusillade"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "2.1.0", path = "crates/fusillade-core" }
+fusillade-core = { version = "3.0.0", path = "crates/fusillade-core" }
 fusillade-arsenal = { version = "2.1.0", path = "crates/fusillade-arsenal", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/crates/fusillade-arsenal/Cargo.toml
+++ b/crates/fusillade-arsenal/Cargo.toml
@@ -10,7 +10,7 @@ name = "fusillade_arsenal"
 path = "src/lib.rs"
 
 [dependencies]
-fusillade-core = { version = "2.1.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
+fusillade-core = { version = ">=2.1.0, <4.0.0", path = "../fusillade-core", features = ["sqlx-postgres"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ test *args="":
 
 test-release-scripts:
     bash .github/scripts/test-publish-crate.sh
+    bash .github/scripts/test-sync-release-dependencies.sh
 
 test-arsenal-sqlx-cache:
     bash .github/scripts/test-arsenal-sqlx-cache.sh


### PR DESCRIPTION
## Summary

- repair workspace requirements after an independently released crate changes major version
- keep compatible cross-major requirements intact
- update Release Please pull requests automatically when tracked workspace versions no longer satisfy their dependants
- cover synchronization and check-only behavior with release-script tests

## Verification

- `just test-release-scripts`
- `cargo metadata --format-version 1`
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`