### PR TITLE
fix: resolve tracked versions before publishing

### DIFF
--- a/.github/scripts/publish-crate.sh
+++ b/.github/scripts/publish-crate.sh
@@ -27,10 +27,14 @@ manifest_version() {
   sed -n 's/^version = "\([^"]*\)".*/\1/p' "$manifest" | head -n 1
 }
 
-dependency_version() {
-  local manifest="$1"
-  local dependency="$2"
-  sed -n "s/^${dependency} = { version = \"\\([^\"]*\\)\".*/\\1/p" "$manifest" | head -n 1
+release_manifest_version() {
+  local package_path="$1"
+  awk -v key="\"${package_path}\":" '
+    $1 == key {
+      gsub(/[",]/, "", $2)
+      print $2
+    }
+  ' .release-please-manifest.json
 }
 
 crate_version_available() {
@@ -95,13 +99,12 @@ case "$package" in
   fusillade-arsenal)
     wait_for_crate_version \
       fusillade-core \
-      "$(dependency_version "$(manifest_for_package "$package")" fusillade-core)"
+      "$(release_manifest_version crates/fusillade-core)"
     publish_package "$package"
     ;;
   fusillade)
-    root_manifest="$(manifest_for_package "$package")"
-    wait_for_crate_version fusillade-core "$(dependency_version "$root_manifest" fusillade-core)"
-    wait_for_crate_version fusillade-arsenal "$(dependency_version "$root_manifest" fusillade-arsenal)"
+    wait_for_crate_version fusillade-core "$(release_manifest_version crates/fusillade-core)"
+    wait_for_crate_version fusillade-arsenal "$(release_manifest_version crates/fusillade-arsenal)"
     publish_package "$package"
     ;;
 esac

--- a/.github/scripts/test-publish-crate.sh
+++ b/.github/scripts/test-publish-crate.sh
@@ -24,6 +24,10 @@ if [[ "$saw_user_agent" != 1 ]]; then
   echo "curl was called without a User-Agent" >&2
   exit 22
 fi
+
+if [[ -n "${CURL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"$CURL_LOG"
+fi
 STUB
 
 cat >"$tmpdir/cargo" <<'STUB'
@@ -38,6 +42,22 @@ chmod +x "$tmpdir/curl" "$tmpdir/cargo"
 
 core_version="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' crates/fusillade-core/Cargo.toml | head -n 1)"
 PATH="$tmpdir:$PATH" .github/scripts/publish-crate.sh "fusillade-core-v${core_version}"
+
+arsenal_version="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' crates/fusillade-arsenal/Cargo.toml | head -n 1)"
+CURL_LOG="$tmpdir/curl.log" PATH="$tmpdir:$PATH" \
+  .github/scripts/publish-crate.sh "fusillade-arsenal-v${arsenal_version}"
+if ! grep -Fq "/fusillade-core/${core_version}" "$tmpdir/curl.log"; then
+  echo "arsenal publishing must wait for the concrete tracked core version" >&2
+  exit 1
+fi
+
+root_version="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' Cargo.toml | head -n 1)"
+CURL_LOG="$tmpdir/curl.log" PATH="$tmpdir:$PATH" \
+  .github/scripts/publish-crate.sh "fusillade-v${root_version}"
+if ! grep -Fq "/fusillade-arsenal/${arsenal_version}" "$tmpdir/curl.log"; then
+  echo "root publishing must wait for the concrete tracked arsenal version" >&2
+  exit 1
+fi
 
 publish_job_block="$(awk '
   /^  publish:/ { in_publish = 1; print; next }


### PR DESCRIPTION
## Summary

- resolve internal workspace dependencies to their concrete release-manifest versions before polling crates.io
- support compatible dependency ranges during ordered publishing
- cover dependent root and storage publishing with regression checks

## Verification

- `just test-release-scripts`
- `bash .github/scripts/test-arsenal-sqlx-cache.sh`
- `cargo metadata --format-version 1`
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`